### PR TITLE
Make TraceEvent.stackTraceHolder nullable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,8 @@ Contributors: Timon Kanters, Jeroen Erik Jensen
 
 * Minor bug fixes.
 
+* Make TraceEvent.stackTraceHolder nullable.
+
 ### 1.0.13
 
 * Bug fix, renaming non-DEX formattable function name.

--- a/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceEvent.kt
+++ b/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceEvent.kt
@@ -25,7 +25,7 @@ import java.time.LocalDateTime
  * @param tracerClassName Class logging the event.
  * @param taggingClassName Tagging class passed to event, for convenience of debugging.
  * @param interfaceName Interface name, derived from [TraceEventListener].
- * @param stackTraceHolder Throwable from which a stack trace can be produced.
+ * @param stackTraceHolder Throwable from which a stack trace can be produced. `null` when unavailable.
  * @param eventName Function name in interface, which represents the trace event name.
  * @param args Trace event arguments. Specified as array, to avoid expensive array/list conversions.
  */
@@ -35,7 +35,7 @@ data class TraceEvent(
     val tracerClassName: String,
     val taggingClassName: String,
     val interfaceName: String,
-    val stackTraceHolder: Throwable,
+    val stackTraceHolder: Throwable?,
     val eventName: String,
     val args: Array<Any?>
 ) {
@@ -67,7 +67,7 @@ data class TraceEvent(
         result = 31 * result + tracerClassName.hashCode()
         result = 31 * result + taggingClassName.hashCode()
         result = 31 * result + interfaceName.hashCode()
-        result = 31 * result + stackTraceHolder.hashCode()
+        result = 31 * result + (stackTraceHolder?.hashCode() ?: 0)
         result = 31 * result + eventName.hashCode()
         result = 31 * result + args.contentDeepHashCode()
         return result

--- a/traceevents/src/main/java/com/tomtom/kotlin/traceevents/Tracer.kt
+++ b/traceevents/src/main/java/com/tomtom/kotlin/traceevents/Tracer.kt
@@ -707,7 +707,7 @@ class Tracer private constructor(
                 } else {
                     "unavailable"
                 }
-                sb.append(", fileLocation=$fileLocation}")
+                sb.append(", fileLocation=$fileLocation")
             }
 
             // Source class name.

--- a/traceevents/src/main/java/com/tomtom/kotlin/traceevents/Tracer.kt
+++ b/traceevents/src/main/java/com/tomtom/kotlin/traceevents/Tracer.kt
@@ -702,7 +702,12 @@ class Tracer private constructor(
 
             // Called-from file location.
             if (includeFileLocation) {
-                sb.append(", fileLocation=${getSourceCodeLocation(traceEvent.stackTraceHolder)}")
+                val fileLocation = if (traceEvent.stackTraceHolder != null) {
+                    getSourceCodeLocation(traceEvent.stackTraceHolder)
+                } else {
+                    "unavailable"
+                }
+                sb.append(", fileLocation=$fileLocation}")
             }
 
             // Source class name.


### PR DESCRIPTION
It is not possible to serialize/deserialize a `Throwable`. This change makes it possible to construct a `TraceEvent` from serialized data.