### PR TITLE
Make TraceEventConsumerCollection a public class

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,13 +442,13 @@ Contributors: Timon Kanters, Jeroen Erik Jensen
 
 ### 1.0.15
 
-* ...
+* Made `TraceEventConsumerCollection` a public class to be able to use it also for consuming streamed events.
 
 ### 1.0.14
 
 * Minor bug fixes.
 
-* Make `TraceEvent.stackTraceHolder` nullable.
+* Made `TraceEvent.stackTraceHolder` nullable.
 
 ### 1.0.13
 

--- a/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceEventConsumerCollection.kt
+++ b/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceEventConsumerCollection.kt
@@ -29,7 +29,7 @@ import kotlin.reflect.jvm.javaMethod
  * This class registers event tracer consumer and finds (and caches) the functions in those
  * consumer to call (by inspection) when events need to be handled.
  */
-internal class TraceEventConsumerCollection {
+class TraceEventConsumerCollection {
 
     fun add(traceEventConsumer: TraceEventConsumer) {
         traceEventsConsumers.add(traceEventConsumer)


### PR DESCRIPTION
Allow `TraceEventConsumerCollection` to be used for consuming streamed events.