### PR TITLE
TraceEventConsumerCollection log fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,10 @@ Contributors: Timon Kanters, Jeroen Erik Jensen
 
 ## Release notes
 
+### 1.0.17
+
+* Minor bug fixes.
+
 ### 1.0.16
 
 * Updated dependencies. No functional changes.

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>com.tomtom.kotlin</groupId>
     <artifactId>kotlin-tools</artifactId>
-    <version>1.0.16</version>
+    <version>1.0.17-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Kotlin Tools</name>

--- a/traceevents/pom.xml
+++ b/traceevents/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.kotlin</groupId>
         <artifactId>kotlin-tools</artifactId>
-        <version>1.0.16</version>
+        <version>1.0.17-SNAPSHOT</version>
     </parent>
 
     <artifactId>traceevents</artifactId>

--- a/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceEventConsumerCollection.kt
+++ b/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceEventConsumerCollection.kt
@@ -93,9 +93,9 @@ class TraceEventConsumerCollection {
                 } else {
                     TraceLog.log(
                         LogLevel.ERROR, TAG, "Method not found, " +
-                            "traceEventConsumer=${traceEventConsumer::class}" +
-                            "traceEventListener=$traceEventListener" +
-                            "traceEvent.functionName=${traceEvent.eventName}" +
+                            "traceEventConsumer=${traceEventConsumer::class}, " +
+                            "traceEventListener=$traceEventListener, " +
+                            "traceEvent.functionName=${traceEvent.eventName}, " +
                             "traceEvent.args.size=${traceEvent.args.size}"
                     )
                 }


### PR DESCRIPTION
Fix the format of `Method not found` log entry and do not log this for each consumer that isn't an subclass of the trace event listener interface.