### PR TITLE
Adding function memoization extensions to kotlin tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
-# Created by https://www.gitignore.io/api/maven,kotlin,intellij
-# Edit at https://www.gitignore.io/?templates=maven,kotlin,intellij
+# Created by https://www.toptal.com/developers/gitignore/api/maven,kotlin,intellij
+# Edit at https://www.toptal.com/developers/gitignore?templates=maven,kotlin,intellij
 
 ### Intellij ###
-# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
 # User-specific stuff
@@ -32,11 +32,14 @@
 # When using Gradle or Maven with auto-import, you should exclude module files,
 # since they will be recreated, and may cause churn.  Uncomment if using
 # auto-import.
-# .idea/modules.xml
-# .idea/*.iml
-# .idea/modules
-# *.iml
-# *.ipr
+.idea/artifacts
+.idea/compiler.xml
+.idea/jarRepositories.xml
+.idea/modules.xml
+.idea/*.iml
+.idea/modules
+*.iml
+*.ipr
 
 # CMake
 cmake-build-*/
@@ -80,14 +83,26 @@ fabric.properties
 # *.ipr
 
 # Sonarlint plugin
+# https://plugins.jetbrains.com/plugin/7973-sonarlint
 .idea/**/sonarlint/
 
 # SonarQube Plugin
+# https://plugins.jetbrains.com/plugin/7238-sonarqube-community-plugin
 .idea/**/sonarIssues.xml
 
 # Markdown Navigator plugin
+# https://plugins.jetbrains.com/plugin/7896-markdown-navigator-enhanced
 .idea/**/markdown-navigator.xml
+.idea/**/markdown-navigator-enh.xml
 .idea/**/markdown-navigator/
+
+# Cache file creation bug
+# See https://youtrack.jetbrains.com/issue/JBR-2257
+.idea/$CACHE_FILE$
+
+# CodeStream plugin
+# https://plugins.jetbrains.com/plugin/12206-codestream
+.idea/codestream.xml
 
 ### Kotlin ###
 # Compiled class file
@@ -124,7 +139,7 @@ release.properties
 dependency-reduced-pom.xml
 buildNumber.properties
 .mvn/timing.properties
+# https://github.com/takari/maven-wrapper#usage-without-binary-jar
 .mvn/wrapper/maven-wrapper.jar
-.flattened-pom.xml
 
-# End of https://www.gitignore.io/api/maven,kotlin,intellij
+# End of https://www.toptal.com/developers/gitignore/api/maven,kotlin,intellij

--- a/.idea/copyright/Tomtom.xml
+++ b/.idea/copyright/Tomtom.xml
@@ -1,0 +1,6 @@
+<component name="CopyrightManager">
+  <copyright>
+    <option name="notice" value="Copyright (C) 2020-2020, TomTom (http://tomtom.com).&#10;Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);&#10;you may not use this file except in compliance with the License.&#10;You may obtain a copy of the License at&#10;&#10;    http://www.apache.org/licenses/LICENSE-2.0&#10;&#10;Unless required by applicable law or agreed to in writing, software&#10;distributed under the License is distributed on an &quot;AS IS&quot; BASIS,&#10;WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#10;See the License for the specific language governing permissions and&#10;limitations under the License." />
+    <option name="myName" value="Tomtom" />
+  </copyright>
+</component>

--- a/.idea/copyright/Tomtom.xml
+++ b/.idea/copyright/Tomtom.xml
@@ -1,6 +1,6 @@
 <component name="CopyrightManager">
   <copyright>
-    <option name="notice" value="Copyright (C) 2020-2020, TomTom (http://tomtom.com).&#10;Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);&#10;you may not use this file except in compliance with the License.&#10;You may obtain a copy of the License at&#10;&#10;    http://www.apache.org/licenses/LICENSE-2.0&#10;&#10;Unless required by applicable law or agreed to in writing, software&#10;distributed under the License is distributed on an &quot;AS IS&quot; BASIS,&#10;WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#10;See the License for the specific language governing permissions and&#10;limitations under the License." />
+    <option name="notice" value="Copyright (C) 2020-&amp;#36;today.year, TomTom (http://tomtom.com).&#10;Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);&#10;you may not use this file except in compliance with the License.&#10;You may obtain a copy of the License at&#10;&#10;    http://www.apache.org/licenses/LICENSE-2.0&#10;&#10;Unless required by applicable law or agreed to in writing, software&#10;distributed under the License is distributed on an &quot;AS IS&quot; BASIS,&#10;WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#10;See the License for the specific language governing permissions and&#10;limitations under the License." />
     <option name="myName" value="Tomtom" />
   </copyright>
 </component>

--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,0 +1,7 @@
+<component name="CopyrightManager">
+  <settings default="Tomtom">
+    <module2copyright>
+      <element module="Project Files" copyright="Tomtom" />
+    </module2copyright>
+  </settings>
+</component>

--- a/README.md
+++ b/README.md
@@ -423,8 +423,8 @@ val personId : messageId as Uid<Person>     // type to another using 'as'. This 
 
 ## Module: Function-Memoization
 
-Provides `memoize` extension to kotlin functions that allows optimizing expensive functions by 
-remembering the results corresponding to some set of specific inputs.
+Provides `memoize` extension to Kotlin functions that allows optimizing expensive functions by 
+caching the results corresponding to some set of specific inputs.
 
 
 ```kotlin

--- a/README.md
+++ b/README.md
@@ -426,7 +426,12 @@ val personId : messageId as Uid<Person>     // type to another using 'as'. This 
 Provides `memoize` extension to Kotlin functions that allows optimizing expensive functions by 
 caching the results corresponding to some set of specific inputs.
 
+In order for memoization to work properly:
+- input arguments should be comparable with proper equals/hashcode implementations
+- given the same input, function should always return same output
 
+
+example:
 ```kotlin
 val function1: (Int) -> String = { p1: Int -> p1.toString() }.memoize()
 

--- a/README.md
+++ b/README.md
@@ -421,6 +421,23 @@ val personId : messageId as Uid<Person>     // type to another using 'as'. This 
                                             // in serialization.
 ```
 
+## Module: Function-Memoization
+
+Provides `memoize` extension to kotlin functions that allows optimizing expensive functions by 
+remembering the results corresponding to some set of specific inputs.
+
+
+```kotlin
+val function1: (Int) -> String = { p1: Int -> p1.toString() }.memoize()
+
+function1(10) // First call with 10 - actual function is called and result is cached
+function1(11) // First call with 11 - actual function is called and result is cached
+function1(10) // Second call with 10 - value is returned from cache
+```
+
+`memoize()` - extension creates cached function with unlimited storage capacity.
+`memoize(Int)` - extension creates Least Recently Used (LRU) cached function that will remove least recently used item if number of stored results exceeds provided limit.
+
 ## License
 
 Copyright (C) 2020-2020, TomTom (http://tomtom.com).
@@ -466,9 +483,13 @@ And then choose the pre-defined style `Kotlin Style Guide`. Voila!
 
 Author: Rijn Buve
 
-Contributors: Timon Kanters, Jeroen Erik Jensen
+Contributors: Timon Kanters, Jeroen Erik Jensen, Krzysztof Karczewski
 
 ## Release notes
+
+### 1.2.0
+
+* Added kotlin function memoization extensions.
 
 ### 1.1.1
 

--- a/function-memoization/pom.xml
+++ b/function-memoization/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2020-2020, TomTom (http://tomtom.com).
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <!-- Use the speedtools shared pom. -->
+    <parent>
+        <groupId>com.tomtom.kotlin</groupId>
+        <artifactId>kotlin-tools</artifactId>
+        <version>1.1.1</version>
+    </parent>
+
+    <artifactId>function-memoization</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Function memoization extensions</name>
+
+    <!--
+        Don't add a description if you want the project not to be picked up by the maven-mailinglist-plugin
+        (if the plugin is enabled).
+    -->
+    <description>
+        Kotlin functions extensions that allows memoization.
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+        </dependency>
+        <!-- Test scope. -->
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-test-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/function-memoization/pom.xml
+++ b/function-memoization/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.kotlin</groupId>
         <artifactId>kotlin-tools</artifactId>
-        <version>1.1.1</version>
+        <version>1.2.0</version>
     </parent>
 
     <artifactId>function-memoization</artifactId>

--- a/function-memoization/src/main/java/com/tomtom/kotlin/FunctionMemoizationExtensions.kt
+++ b/function-memoization/src/main/java/com/tomtom/kotlin/FunctionMemoizationExtensions.kt
@@ -17,7 +17,7 @@
 package com.tomtom.kotlin
 
 /**
- * Creates a memoized function that will return cached result when the same inputs occurs again.
+ * Creates a memoized function that will return cached result when the same input occurs again.
  */
 fun <R> (() -> R).memoize(): () -> R =
     object : () -> R {
@@ -26,19 +26,19 @@ fun <R> (() -> R).memoize(): () -> R =
     }
 
 /**
- * Creates a LRU style cached function that will return cached result when the same inputs occurs again.
+ * Creates a LRU style cached function that will return cached result when the same input occurs again.
  */
 fun <P1, R> ((P1) -> R).memoize(cacheSize: Int): (P1) -> R =
     Function1Cache(this, cacheSize = cacheSize)
 
 /**
- * Creates a memoized function that will return cached result when the same inputs occurs again.
+ * Creates a memoized function that will return cached result when the same input occurs again.
  */
 fun <P1, R> ((P1) -> R).memoize(): (P1) -> R =
     Function1Cache(this)
 
 /**
- * Creates a LRU style cached function that will return cached result when the same inputs occurs again.
+ * Creates a LRU style cached function that will return cached result when the same input occurs again.
  */
 fun <P1, P2, R> ((P1, P2) -> R).memoize(cacheSize: Int): (P1, P2) -> R =
     object : (P1, P2) -> R {
@@ -50,7 +50,7 @@ fun <P1, P2, R> ((P1, P2) -> R).memoize(cacheSize: Int): (P1, P2) -> R =
     }
 
 /**
- * Creates a memoized function that will return cached result when the same inputs occurs again.
+ * Creates a memoized function that will return cached result when the same input occurs again.
  */
 fun <P1, P2, R> ((P1, P2) -> R).memoize(): (P1, P2) -> R =
     object : (P1, P2) -> R {
@@ -63,7 +63,7 @@ fun <P1, P2, R> ((P1, P2) -> R).memoize(): (P1, P2) -> R =
 
 
 /**
- * Creates a LRU style cached function that will return cached result when the same inputs occurs again.
+ * Creates a LRU style cached function that will return cached result when the same input occurs again.
  */
 fun <P1, P2, P3, R> ((P1, P2, P3) -> R).memoize(cacheSize: Int): (P1, P2, P3) -> R =
     object : (P1, P2, P3) -> R {
@@ -75,7 +75,7 @@ fun <P1, P2, P3, R> ((P1, P2, P3) -> R).memoize(cacheSize: Int): (P1, P2, P3) ->
     }
 
 /**
- * Creates a memoized function that will return cached result when the same inputs occurs again.
+ * Creates a memoized function that will return cached result when the same input occurs again.
  */
 fun <P1, P2, P3, R> ((P1, P2, P3) -> R).memoize(): (P1, P2, P3) -> R =
     object : (P1, P2, P3) -> R {
@@ -87,7 +87,7 @@ fun <P1, P2, P3, R> ((P1, P2, P3) -> R).memoize(): (P1, P2, P3) -> R =
     }
 
 /**
- * Creates a LRU style cached function that will return cached result when the same inputs occurs again.
+ * Creates a LRU style cached function that will return cached result when the same input occurs again.
  */
 fun <P1, P2, P3, P4, R> ((P1, P2, P3, P4) -> R).memoize(cacheSize: Int): (P1, P2, P3, P4) -> R =
     object : (P1, P2, P3, P4) -> R {
@@ -99,7 +99,7 @@ fun <P1, P2, P3, P4, R> ((P1, P2, P3, P4) -> R).memoize(cacheSize: Int): (P1, P2
     }
 
 /**
- * Creates a memoized function that will return cached result when the same inputs occurs again.
+ * Creates a memoized function that will return cached result when the same input occurs again.
  */
 fun <P1, P2, P3, P4, R> ((P1, P2, P3, P4) -> R).memoize(): (P1, P2, P3, P4) -> R =
     object : (P1, P2, P3, P4) -> R {

--- a/function-memoization/src/main/java/com/tomtom/kotlin/FunctionMemoizationExtensions.kt
+++ b/function-memoization/src/main/java/com/tomtom/kotlin/FunctionMemoizationExtensions.kt
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2020-present, TomTom N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tomtom.kotlin
+
+/**
+ * Creates a memoized function that will return cached result when the same inputs occurs again.
+ */
+fun <R> (() -> R).memoize(): () -> R =
+    object : () -> R {
+        val result by lazy(LazyThreadSafetyMode.NONE) { this@memoize() }
+        override fun invoke(): R = result
+    }
+
+/**
+ * Creates a LRU style cached function that will return cached result when the same inputs occurs again.
+ */
+fun <P1, R> ((P1) -> R).memoize(cacheSize: Int): (P1) -> R =
+    Function1Cache(this, cacheSize = cacheSize)
+
+/**
+ * Creates a memoized function that will return cached result when the same inputs occurs again.
+ */
+fun <P1, R> ((P1) -> R).memoize(): (P1) -> R =
+    Function1Cache(this)
+
+/**
+ * Creates a LRU style cached function that will return cached result when the same inputs occurs again.
+ */
+fun <P1, P2, R> ((P1, P2) -> R).memoize(cacheSize: Int = 1): (P1, P2) -> R =
+    object : (P1, P2) -> R {
+        private val cache = { pair: Pair<P1, P2> ->
+            this@memoize(pair.first, pair.second)
+        }.memoize(cacheSize = cacheSize)
+
+        override fun invoke(p1: P1, p2: P2): R = cache.invoke(Pair(p1, p2))
+    }
+
+/**
+ * Creates a memoized function that will return cached result when the same inputs occurs again.
+ */
+fun <P1, P2, R> ((P1, P2) -> R).memoize(): (P1, P2) -> R =
+    object : (P1, P2) -> R {
+        private val cache = { pair: Pair<P1, P2> ->
+            this@memoize(pair.first, pair.second)
+        }.memoize()
+
+        override fun invoke(p1: P1, p2: P2): R = cache.invoke(Pair(p1, p2))
+    }
+
+
+/**
+ * Creates a LRU style cached function that will return cached result when the same inputs occurs again.
+ */
+fun <P1, P2, P3, R> ((P1, P2, P3) -> R).memoize(cacheSize: Int = 1): (P1, P2, P3) -> R =
+    object : (P1, P2, P3) -> R {
+        private val cache = { triple: Triple<P1, P2, P3> ->
+            this@memoize(triple.first, triple.second, triple.third)
+        }.memoize(cacheSize = cacheSize)
+
+        override fun invoke(p1: P1, p2: P2, p3: P3): R = cache.invoke(Triple(p1, p2, p3))
+    }
+
+/**
+ * Creates a memoized function that will return cached result when the same inputs occurs again.
+ */
+fun <P1, P2, P3, R> ((P1, P2, P3) -> R).memoize(): (P1, P2, P3) -> R =
+    object : (P1, P2, P3) -> R {
+        private val cache = { triple: Triple<P1, P2, P3> ->
+            this@memoize(triple.first, triple.second, triple.third)
+        }.memoize()
+
+        override fun invoke(p1: P1, p2: P2, p3: P3): R = cache.invoke(Triple(p1, p2, p3))
+    }
+
+/**
+ * Creates a LRU style cached function that will return cached result when the same inputs occurs again.
+ */
+fun <P1, P2, P3, P4, R> ((P1, P2, P3, P4) -> R).memoize(cacheSize: Int): (P1, P2, P3, P4) -> R =
+    object : (P1, P2, P3, P4) -> R {
+        private val cache = { quadruple: Quadruple<P1, P2, P3, P4> ->
+            this@memoize(quadruple.first, quadruple.second, quadruple.third, quadruple.fourth)
+        }.memoize(cacheSize = cacheSize)
+
+        override fun invoke(p1: P1, p2: P2, p3: P3, p4: P4): R = cache.invoke(Quadruple(p1, p2, p3, p4))
+    }
+
+/**
+ * Creates a memoized function that will return cached result when the same inputs occurs again.
+ */
+fun <P1, P2, P3, P4, R> ((P1, P2, P3, P4) -> R).memoize(): (P1, P2, P3, P4) -> R =
+    object : (P1, P2, P3, P4) -> R {
+        private val cache = { quadruple: Quadruple<P1, P2, P3, P4> ->
+            this@memoize(quadruple.first, quadruple.second, quadruple.third, quadruple.fourth)
+        }.memoize()
+
+        override fun invoke(p1: P1, p2: P2, p3: P3, p4: P4): R = cache.invoke(Quadruple(p1, p2, p3, p4))
+    }
+
+private class Function1Cache<P1, R>(
+    private val originalFunction: (P1) -> R,
+    // no cache size specified means no limit
+    private val cacheSize: Int? = null
+) : (P1) -> R {
+    private val map = LinkedHashMap<P1, R>(cacheSize ?: 16, 0.75f, true)
+
+    override fun invoke(param1: P1): R {
+        return if (map.containsKey(param1)) {
+            @Suppress("UNCHECKED_CAST")
+            map[param1] as R
+        } else {
+            val value = originalFunction(param1)
+            map[param1] = value
+            if (cacheSize != null && map.size > cacheSize) {
+                // remove last not accessed value
+                map.remove(map.keys.first())
+            }
+            value
+        }
+    }
+}
+
+private data class Quadruple<out A, out B, out C, out D>(
+    val first: A,
+    val second: B,
+    val third: C,
+    val fourth: D
+)

--- a/function-memoization/src/main/java/com/tomtom/kotlin/FunctionMemoizationExtensions.kt
+++ b/function-memoization/src/main/java/com/tomtom/kotlin/FunctionMemoizationExtensions.kt
@@ -1,6 +1,5 @@
 /*
- * Copyright 2020-present, TomTom N.V.
- *
+ * Copyright (C) 2020-2020, TomTom (http://tomtom.com).
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/function-memoization/src/main/java/com/tomtom/kotlin/FunctionMemoizationExtensions.kt
+++ b/function-memoization/src/main/java/com/tomtom/kotlin/FunctionMemoizationExtensions.kt
@@ -115,12 +115,14 @@ private class Function1Cache<P1, R>(
     // no cache size specified means no limit
     private val cacheSize: Int? = null
 ) : (P1) -> R {
-    private val map = LinkedHashMap<P1, R>(cacheSize ?: 16, 0.75f, true)
-
+    private val map = linkedMapOf<P1, R>()
     override fun invoke(param1: P1): R {
         return if (map.containsKey(param1)) {
             @Suppress("UNCHECKED_CAST")
-            map[param1] as R
+            (map.remove(param1) as R).apply {
+                // re-insert result to place it at the end of map
+                map[param1] = this
+            }
         } else {
             val value = originalFunction(param1)
             map[param1] = value

--- a/function-memoization/src/main/java/com/tomtom/kotlin/FunctionMemoizationExtensions.kt
+++ b/function-memoization/src/main/java/com/tomtom/kotlin/FunctionMemoizationExtensions.kt
@@ -40,7 +40,7 @@ fun <P1, R> ((P1) -> R).memoize(): (P1) -> R =
 /**
  * Creates a LRU style cached function that will return cached result when the same inputs occurs again.
  */
-fun <P1, P2, R> ((P1, P2) -> R).memoize(cacheSize: Int = 1): (P1, P2) -> R =
+fun <P1, P2, R> ((P1, P2) -> R).memoize(cacheSize: Int): (P1, P2) -> R =
     object : (P1, P2) -> R {
         private val cache = { pair: Pair<P1, P2> ->
             this@memoize(pair.first, pair.second)
@@ -65,7 +65,7 @@ fun <P1, P2, R> ((P1, P2) -> R).memoize(): (P1, P2) -> R =
 /**
  * Creates a LRU style cached function that will return cached result when the same inputs occurs again.
  */
-fun <P1, P2, P3, R> ((P1, P2, P3) -> R).memoize(cacheSize: Int = 1): (P1, P2, P3) -> R =
+fun <P1, P2, P3, R> ((P1, P2, P3) -> R).memoize(cacheSize: Int): (P1, P2, P3) -> R =
     object : (P1, P2, P3) -> R {
         private val cache = { triple: Triple<P1, P2, P3> ->
             this@memoize(triple.first, triple.second, triple.third)

--- a/function-memoization/src/main/java/com/tomtom/kotlin/FunctionMemoizationExtensions.kt
+++ b/function-memoization/src/main/java/com/tomtom/kotlin/FunctionMemoizationExtensions.kt
@@ -125,7 +125,6 @@ private class Function1Cache<P1, R>(
             val value = originalFunction(param1)
             map[param1] = value
             if (cacheSize != null && map.size > cacheSize) {
-                // remove last not accessed value
                 map.remove(map.keys.first())
             }
             value

--- a/function-memoization/src/test/java/com/tomtom/kotlin/FunctionMemoizationExtensionsTest.kt
+++ b/function-memoization/src/test/java/com/tomtom/kotlin/FunctionMemoizationExtensionsTest.kt
@@ -474,7 +474,7 @@ class FunctionMemoizationExtensionsTest {
             callCounter++
             it
         }
-        val memoizedFunction = function.memoize()
+        val memoizedFunction = function.memoize(100)
         // when
         for (iteration in 1..100) {
             for (arg in 1..100) {
@@ -492,7 +492,7 @@ class FunctionMemoizationExtensionsTest {
             callCounter++
             arg1 + arg2
         }
-        val memoizedFunction = function.memoize()
+        val memoizedFunction = function.memoize(100)
         // when
         for (iteration in 1..100) {
             for (arg in 1..100) {
@@ -511,7 +511,7 @@ class FunctionMemoizationExtensionsTest {
             callCounter++
             arg1 + arg2 + arg3
         }
-        val memoizedFunction = function.memoize()
+        val memoizedFunction = function.memoize(100)
         // when
         for (iteration in 1..100) {
             for (arg in 1..100) {
@@ -531,7 +531,7 @@ class FunctionMemoizationExtensionsTest {
             callCounter++
             arg1 + arg2 + arg3 + arg4
         }
-        val memoizedFunction = function.memoize()
+        val memoizedFunction = function.memoize(100)
         // when
         for (iteration in 1..100) {
             for (arg in 1..100) {

--- a/function-memoization/src/test/java/com/tomtom/kotlin/FunctionMemoizationExtensionsTest.kt
+++ b/function-memoization/src/test/java/com/tomtom/kotlin/FunctionMemoizationExtensionsTest.kt
@@ -1,6 +1,5 @@
 /*
- * Copyright 2020-present, TomTom N.V.
- *
+ * Copyright (C) 2020-2020, TomTom (http://tomtom.com).
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/function-memoization/src/test/java/com/tomtom/kotlin/FunctionMemoizationExtensionsTest.kt
+++ b/function-memoization/src/test/java/com/tomtom/kotlin/FunctionMemoizationExtensionsTest.kt
@@ -1,0 +1,548 @@
+/*
+ * Copyright 2020-present, TomTom N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tomtom.kotlin
+
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class FunctionMemoizationExtensionsTest {
+    private var callCounter = 0
+    private val testString = "Test"
+
+    @Test
+    fun `0 arg memoized function - should be able to cache null output`() {
+        // given
+        val function: () -> String? = {
+            callCounter++
+            null
+        }
+        val memoizedFunction = function.memoize()
+        // when
+        val actual1 = memoizedFunction()
+        val actual2 = memoizedFunction()
+        // then
+        assertNull(actual1)
+        assertNull(actual2)
+        assertEquals(1, callCounter)
+    }
+
+    @Test
+    fun `1 arg memoized function - should be able to cache null output`() {
+        // given
+        val function: (Int) -> String? = {
+            callCounter++
+            null
+        }
+        val memoizedFunction = function.memoize(cacheSize = 1)
+        // when
+        val actual1 = memoizedFunction(1)
+        val actual2 = memoizedFunction(1)
+        // then
+        assertNull(actual1)
+        assertNull(actual2)
+        assertEquals(1, callCounter)
+    }
+
+    @Test
+    fun `2 arg memoized function - should be able to cache null output`() {
+        // given
+        val function: (Int, Int) -> String? = { _, _ ->
+            callCounter++
+            null
+        }
+        val memoizedFunction = function.memoize(cacheSize = 1)
+        // when
+        val actual1 = memoizedFunction(1, 2)
+        val actual2 = memoizedFunction(1, 2)
+        // then
+        assertNull(actual1)
+        assertNull(actual2)
+        assertEquals(1, callCounter)
+    }
+
+    @Test
+    fun `3 arg memoized function - should be able to cache null output`() {
+        // given
+        val function: (Int, Int, Int) -> String? = { _, _, _ ->
+            callCounter++
+            null
+        }
+        val memoizedFunction = function.memoize(cacheSize = 1)
+        // when
+        val actual1 = memoizedFunction(1, 2, 3)
+        val actual2 = memoizedFunction(1, 2, 3)
+        // then
+        assertNull(actual1)
+        assertNull(actual2)
+        assertEquals(1, callCounter)
+    }
+
+    @Test
+    fun `4 arg memoized function - should be able to cache null output`() {
+        // given
+        val function: (Int, Int, Int, Int) -> String? = { _, _, _, _ ->
+            callCounter++
+            null
+        }
+        val memoizedFunction = function.memoize(cacheSize = 1)
+        // when
+        val actual1 = memoizedFunction(1, 2, 3, 4)
+        val actual2 = memoizedFunction(1, 2, 3, 4)
+        // then
+        assertNull(actual1)
+        assertNull(actual2)
+        assertEquals(1, callCounter)
+    }
+
+    @Test
+    fun `0 arg memoized function - should call function only once`() {
+        // given
+        val function: () -> String? = {
+            callCounter++
+            testString
+        }
+        val memoizedFunction = function.memoize()
+        // when
+        val actual1 = memoizedFunction()
+        val actual2 = memoizedFunction()
+        val actual3 = memoizedFunction()
+        // then
+        assertEquals(testString, actual1)
+        assertEquals(testString, actual2)
+        assertEquals(testString, actual3)
+        assertEquals(1, callCounter)
+    }
+
+    @Test
+    fun `1 arg memoized function - should call function only once when using same input`() {
+        // given
+        val function: (Int) -> String? = {
+            callCounter++
+            testString
+        }
+        val memoizedFunction = function.memoize(cacheSize = 1)
+        // when
+        val actual1 = memoizedFunction(1)
+        val actual2 = memoizedFunction(1)
+        val actual3 = memoizedFunction(1)
+        // then
+        assertEquals(testString, actual1)
+        assertEquals(testString, actual2)
+        assertEquals(testString, actual3)
+        assertEquals(1, callCounter)
+    }
+
+    @Test
+    fun `2 arg memoized function - should call function only once when using same input`() {
+        // given
+        val function: (Int, Int) -> String? = { _, _ ->
+            callCounter++
+            testString
+        }
+        val memoizedFunction = function.memoize(cacheSize = 1)
+        // when
+        val actual1 = memoizedFunction(1, 2)
+        val actual2 = memoizedFunction(1, 2)
+        val actual3 = memoizedFunction(1, 2)
+        // then
+        assertEquals(testString, actual1)
+        assertEquals(testString, actual2)
+        assertEquals(testString, actual3)
+        assertEquals(1, callCounter)
+    }
+
+    @Test
+    fun `3 arg memoized function - should call function only once when using same input`() {
+        // given
+        val function: (Int, Int, Int) -> String? = { _, _, _ ->
+            callCounter++
+            testString
+        }
+        val memoizedFunction = function.memoize(cacheSize = 1)
+        // when
+        val actual1 = memoizedFunction(1, 2, 3)
+        val actual2 = memoizedFunction(1, 2, 3)
+        val actual3 = memoizedFunction(1, 2, 3)
+        // then
+        assertEquals(testString, actual1)
+        assertEquals(testString, actual2)
+        assertEquals(testString, actual3)
+        assertEquals(1, callCounter)
+    }
+
+    @Test
+    fun `4 arg memoized function - should call function only once when using same input`() {
+        // given
+        val function: (Int, Int, Int, Int) -> String? = { _, _, _, _ ->
+            callCounter++
+            testString
+        }
+        val memoizedFunction = function.memoize(cacheSize = 1)
+        // when
+        val actual1 = memoizedFunction(1, 2, 3, 4)
+        val actual2 = memoizedFunction(1, 2, 3, 4)
+        val actual3 = memoizedFunction(1, 2, 3, 4)
+        // then
+        assertEquals(testString, actual1)
+        assertEquals(testString, actual2)
+        assertEquals(testString, actual3)
+        assertEquals(1, callCounter)
+    }
+
+    @Test
+    fun `1 arg memoized function - should call function 3 times when using 3 different inputs`() {
+        // given
+        val function: (Int) -> String? = {
+            callCounter++
+            testString + it
+        }
+        val memoizedFunction = function.memoize(2)
+        // when
+        val actual1 = memoizedFunction(1)
+        val actual2 = memoizedFunction(2)
+        val actual3 = memoizedFunction(3)
+        // then
+        assertEquals(testString + 1, actual1)
+        assertEquals(testString + 2, actual2)
+        assertEquals(testString + 3, actual3)
+        assertEquals(3, callCounter)
+    }
+
+    @Test
+    fun `2 arg memoized function - should call function 3 times when using 3 different inputs`() {
+        // given
+        val function: (Int, Int) -> String? = { p1, p2 ->
+            callCounter++
+            testString + p1 + p2
+        }
+        val memoizedFunction = function.memoize(2)
+        // when
+        val actual1 = memoizedFunction(1, 1)
+        val actual2 = memoizedFunction(2, 1)
+        val actual3 = memoizedFunction(2, 2)
+        // then
+        assertEquals(testString + 1 + 1, actual1)
+        assertEquals(testString + 2 + 1, actual2)
+        assertEquals(testString + 2 + 2, actual3)
+        assertEquals(3, callCounter)
+    }
+
+    @Test
+    fun `3 arg memoized function - should call function 4 times when using 4 different inputs`() {
+        // given
+        val function: (Int, Int, Int) -> String? = { p1, p2, p3 ->
+            callCounter++
+            testString + p1 + p2 + p3
+        }
+        val memoizedFunction = function.memoize(3)
+        // when
+        val actual1 = memoizedFunction(1, 1, 1)
+        val actual2 = memoizedFunction(2, 1, 1)
+        val actual3 = memoizedFunction(2, 2, 1)
+        val actual4 = memoizedFunction(2, 2, 2)
+
+        // then
+        assertEquals(testString + 1 + 1 + 1, actual1)
+        assertEquals(testString + 2 + 1 + 1, actual2)
+        assertEquals(testString + 2 + 2 + 1, actual3)
+        assertEquals(testString + 2 + 2 + 2, actual4)
+        assertEquals(4, callCounter)
+    }
+
+    @Test
+    fun `4 arg memoized function - should call function 5 times when using 5 different inputs`() {
+        // given
+        val function: (Int, Int, Int, Int) -> String? = { p1, p2, p3, p4 ->
+            callCounter++
+            testString + p1 + p2 + p3 + p4
+        }
+        val memoizedFunction = function.memoize(3)
+        // when
+        val actual1 = memoizedFunction(1, 1, 1, 1)
+        val actual2 = memoizedFunction(2, 1, 1, 1)
+        val actual3 = memoizedFunction(2, 2, 1, 1)
+        val actual4 = memoizedFunction(2, 2, 2, 1)
+        val actual5 = memoizedFunction(2, 2, 2, 2)
+
+        // then
+        assertEquals(testString + 1 + 1 + 1 + 1, actual1)
+        assertEquals(testString + 2 + 1 + 1 + 1, actual2)
+        assertEquals(testString + 2 + 2 + 1 + 1, actual3)
+        assertEquals(testString + 2 + 2 + 2 + 1, actual4)
+        assertEquals(testString + 2 + 2 + 2 + 2, actual5)
+        assertEquals(5, callCounter)
+    }
+
+    @Test
+    fun `1 arg memoized function - should call function 2 times when value evicted from the cache`() {
+        // given
+        var callCounterForOne = 0
+        val function: (Int) -> String? = {
+            if (it == 1) callCounterForOne++
+            testString + it
+        }
+        val memoizedFunction = function.memoize(2)
+        // when
+        val actual1 = memoizedFunction(1)
+        val actual2 = memoizedFunction(2)
+        // getting 3 should remove result 1
+        val actual3 = memoizedFunction(3)
+        val actual4 = memoizedFunction(1)
+
+        // then
+        assertEquals(testString + 1, actual1)
+        assertEquals(testString + 2, actual2)
+        assertEquals(testString + 3, actual3)
+        assertEquals(testString + 1, actual4)
+        assertEquals(2, callCounterForOne)
+    }
+
+    @Test
+    fun `2 arg memoized function - should call function 2 times when value evicted from the cache`() {
+        // given
+        var callCounterForOne = 0
+        val function: (Int, Int) -> String? = { p1, p2 ->
+            if (p1 == 1 && p2 == 1) callCounterForOne++
+            testString + p1 + p2
+        }
+        val memoizedFunction = function.memoize(2)
+        // when
+        val actual1 = memoizedFunction(1, 1)
+        val actual2 = memoizedFunction(2, 1)
+        // getting 3 should remove result 1
+        val actual3 = memoizedFunction(2, 2)
+        val actual4 = memoizedFunction(1, 1)
+
+        // then
+        assertEquals(testString + 1 + 1, actual1)
+        assertEquals(testString + 2 + 1, actual2)
+        assertEquals(testString + 2 + 2, actual3)
+        assertEquals(testString + 1 + 1, actual4)
+        assertEquals(2, callCounterForOne)
+    }
+
+    @Test
+    fun `3 arg memoized function - should call function 2 times when value evicted from the cache`() {
+        // given
+        var callCounterForOne = 0
+        val function: (Int, Int, Int) -> String? = { p1, p2, p3 ->
+            if (p1 == 1 && p2 == 1 && p3 == 1) callCounterForOne++
+            testString + p1 + p2 + p3
+        }
+        val memoizedFunction = function.memoize(2)
+        // when
+        val actual1 = memoizedFunction(1, 1, 1)
+        val actual2 = memoizedFunction(2, 1, 1)
+        // getting 3 should remove result 1
+        val actual3 = memoizedFunction(2, 2, 1)
+        val actual4 = memoizedFunction(1, 1, 1)
+
+        // then
+        assertEquals(testString + 1 + 1 + 1, actual1)
+        assertEquals(testString + 2 + 1 + 1, actual2)
+        assertEquals(testString + 2 + 2 + 1, actual3)
+        assertEquals(testString + 1 + 1 + 1, actual4)
+        assertEquals(2, callCounterForOne)
+    }
+
+    @Test
+    fun `4 arg memoized function - should call function 2 times when value evicted from the cache`() {
+        // given
+        var callCounterForOne = 0
+        val function: (Int, Int, Int, Int) -> String? = { p1, p2, p3, p4 ->
+            if (p1 == 1 && p2 == 1 && p3 == 1) callCounterForOne++
+            testString + p1 + p2 + p3 + p4
+        }
+        val memoizedFunction = function.memoize(2)
+        // when
+        val actual1 = memoizedFunction(1, 1, 1, 1)
+        val actual2 = memoizedFunction(2, 1, 1, 1)
+        // getting 3 should remove result 1
+        val actual3 = memoizedFunction(2, 2, 1, 1)
+        val actual4 = memoizedFunction(1, 1, 1, 1)
+
+        // then
+        assertEquals(testString + 1 + 1 + 1 + 1, actual1)
+        assertEquals(testString + 2 + 1 + 1 + 1, actual2)
+        assertEquals(testString + 2 + 2 + 1 + 1, actual3)
+        assertEquals(testString + 1 + 1 + 1 + 1, actual4)
+        assertEquals(2, callCounterForOne)
+    }
+
+    @Test
+    fun `1 arg memoized function - should be able to cache null input`() {
+        // given
+        val function: (Int?) -> String? = {
+            callCounter++
+            testString + it
+        }
+        val memoizedFunction = function.memoize(2)
+        // when
+        val actual1 = memoizedFunction(null)
+        val actual2 = memoizedFunction(1)
+
+        // then
+        assertEquals(testString + null, actual1)
+        assertEquals(testString + 1, actual2)
+        assertEquals(2, callCounter)
+    }
+
+    @Test
+    fun `2 arg memoized function - should be able to cache null input`() {
+        // given
+        val function: (Int?, Int?) -> String? = { p1, p2 ->
+            callCounter++
+            testString + p1 + p2
+        }
+        val memoizedFunction = function.memoize(2)
+        // when
+        val actual1 = memoizedFunction(null, 1)
+        val actual2 = memoizedFunction(null, null)
+        val actual3 = memoizedFunction(1, 1)
+
+        // then
+        assertEquals(testString + null + 1, actual1)
+        assertEquals(testString + null + null, actual2)
+        assertEquals(testString + 1 + 1, actual3)
+        assertEquals(3, callCounter)
+    }
+
+    @Test
+    fun `3 arg memoized function - should be able to cache null input`() {
+        // given
+        val function: (Int?, Int?, Int?) -> String? = { p1, p2, p3 ->
+            callCounter++
+            testString + p1 + p2 + p3
+        }
+        val memoizedFunction = function.memoize(2)
+        // when
+        val actual1 = memoizedFunction(null, 1, 1)
+        val actual2 = memoizedFunction(null, null, 1)
+        val actual3 = memoizedFunction(null, null, null)
+        val actual4 = memoizedFunction(1, 1, 1)
+
+        // then
+        assertEquals(testString + null + 1 + 1, actual1)
+        assertEquals(testString + null + null + 1, actual2)
+        assertEquals(testString + null + null + null, actual3)
+        assertEquals(testString + 1 + 1 + 1, actual4)
+        assertEquals(4, callCounter)
+    }
+
+    @Test
+    fun `4 arg memoized function - should be able to cache null input`() {
+        // given
+        val function: (Int?, Int?, Int?, Int?) -> String? = { p1, p2, p3, p4 ->
+            callCounter++
+            testString + p1 + p2 + p3 + p4
+        }
+        val memoizedFunction = function.memoize(2)
+        // when
+        val actual1 = memoizedFunction(null, 1, 1, 1)
+        val actual2 = memoizedFunction(null, null, 1, 1)
+        val actual3 = memoizedFunction(null, null, null, 1)
+        val actual4 = memoizedFunction(null, null, null, null)
+        val actual5 = memoizedFunction(1, 1, 1, 1)
+
+        // then
+        assertEquals(testString + null + 1 + 1 + 1, actual1)
+        assertEquals(testString + null + null + 1 + 1, actual2)
+        assertEquals(testString + null + null + null + 1, actual3)
+        assertEquals(testString + null + null + null + null, actual4)
+        assertEquals(testString + 1 + 1 + 1 + 1, actual5)
+        assertEquals(5, callCounter)
+    }
+
+    @Test
+    fun `1 arg memoized function should memoize 100 results`() {
+        // given
+        val function: (Int) -> Int = {
+            callCounter++
+            it
+        }
+        val memoizedFunction = function.memoize()
+        // when
+        for (iteration in 1..100) {
+            for (arg in 1..100) {
+                assertEquals(arg, memoizedFunction(arg))
+            }
+        }
+        // then
+        assertEquals(100, callCounter)
+    }
+
+    @Test
+    fun `2 arg memoized function should memoize 100 results`() {
+        // given
+        val function: (Int, Int) -> Int = { arg1, arg2 ->
+            callCounter++
+            arg1 + arg2
+        }
+        val memoizedFunction = function.memoize()
+        // when
+        for (iteration in 1..100) {
+            for (arg in 1..100) {
+                val arg2 = arg % 10
+                assertEquals(arg + arg2, memoizedFunction(arg, arg2))
+            }
+        }
+        // then
+        assertEquals(100, callCounter)
+    }
+
+    @Test
+    fun `3 arg memoized function should memoize 100 results`() {
+        // given
+        val function: (Int, Int, Int) -> Int = { arg1, arg2, arg3 ->
+            callCounter++
+            arg1 + arg2 + arg3
+        }
+        val memoizedFunction = function.memoize()
+        // when
+        for (iteration in 1..100) {
+            for (arg in 1..100) {
+                val arg2 = arg % 10
+                val arg3 = arg % 25
+                assertEquals(arg + arg2 + arg3, memoizedFunction(arg, arg2, arg3))
+            }
+        }
+        // then
+        assertEquals(100, callCounter)
+    }
+
+    @Test
+    fun `4 arg memoized function should memoize 100 results`() {
+        // given
+        val function: (Int, Int, Int, Int) -> Int = { arg1, arg2, arg3, arg4 ->
+            callCounter++
+            arg1 + arg2 + arg3 + arg4
+        }
+        val memoizedFunction = function.memoize()
+        // when
+        for (iteration in 1..100) {
+            for (arg in 1..100) {
+                val arg2 = arg % 10
+                val arg3 = arg % 25
+                val arg4 = arg % 50
+                assertEquals(arg + arg2 + arg3 + arg4, memoizedFunction(arg, arg2, arg3, arg4))
+            }
+        }
+        // then
+        assertEquals(100, callCounter)
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
     <modules>
         <module>traceevents</module>
         <module>uid</module>
+        <module>function-memoization</module>
     </modules>
 
     <properties>
@@ -100,6 +101,7 @@
         <junit-jupiter.version>5.7.0</junit-jupiter.version>
         <kotlin.version>1.4.10</kotlin.version>
         <kotlin-test.version>1.4.10</kotlin-test.version>
+        <kotlin-test-junit.version>1.4.10</kotlin-test-junit.version>
         <kotlinx-coroutines-core.version>1.3.9-native-mt-2</kotlinx-coroutines-core.version>
         <mockito-core.version>3.5.13</mockito-core.version>
         <mockk.version>1.10.0</mockk.version>
@@ -303,6 +305,13 @@
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-test</artifactId>
                 <version>${kotlin-test.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-test-junit</artifactId>
+                <version>${kotlin-test-junit.version}</version>
                 <scope>test</scope>
             </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>com.tomtom.kotlin</groupId>
     <artifactId>kotlin-tools</artifactId>
-    <version>1.1.1</version>
+    <version>1.2.0</version>
     <packaging>pom</packaging>
 
     <name>Kotlin Tools</name>

--- a/traceevents/pom.xml
+++ b/traceevents/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.kotlin</groupId>
         <artifactId>kotlin-tools</artifactId>
-        <version>1.1.1</version>
+        <version>1.2.0</version>
     </parent>
 
     <artifactId>traceevents</artifactId>

--- a/uid/pom.xml
+++ b/uid/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.kotlin</groupId>
         <artifactId>kotlin-tools</artifactId>
-        <version>1.1.1</version>
+        <version>1.2.0</version>
     </parent>
 
     <artifactId>uid</artifactId>


### PR DESCRIPTION
Small yet handy extensions that allow caching function results - a missing feature in Kotlin.
Extensions are done for 0-arg, 1-arg, 2-arg, 3-arg and 4-arg functions yet more can be added if needed.