### PR TITLE
Added context to trace events

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,33 @@ rather than an object reference.
 
 Use `Tracer.resetToDefaults()` to de-register all custom `toString` handlers.
 
+*** Disambiguation Of Trace Event Tracers
+* -------------------------------------
+*
+* Sometimes multiple tracers may exist for a single class (if multiple instances of the tracer are initiated).
+* In those cases, it may be necessary to be able disambiguate the tracer that the trace events came from.
+* This is solved by adding a `context` string to the `create` method. This context string is passed to
+* trace event consumers. Alternatively, trace event consumers can specify a regular expression to make sure
+* they only get the trace events for the specified tracer context(s).
+*
+* ```
+* // Declare 2 tracers.
+* val tracerMain = Tracer.Factory.create<SomeClass>(this::class, "main loop")
+* val tracerSec  = Tracer.Factory.create<SomeClass>(this::class, "secondary")
+*
+* // Declare a consumer for main loop events only.
+* val consumerSpecific = MyEventConsumerForSomeClass()
+* Tracer.addTraceEventConsumer(consumerSpecific, Regex("main.*"));
+*
+* // Declare a consumer for all events.
+* val consumerAll = MyEventConsumerForSomeClass()
+* Tracer.addTraceEventConsumer(consumerAll);
+* ```
+*
+* Note that only `GenericTraceEventConsumer`s are able to retrieve the context passed by the tracer (as it is
+* part of the `TraceEvent` data object. Specific `TraceEventConsumer`s (that implement the original tracer
+* interface), cannot access the context.
+
 ### Advanced examples
 
 Advanced examples of using this trace event mechanism are:
@@ -506,6 +533,10 @@ Author: Rijn Buve
 Contributors: Timon Kanters, Jeroen Erik Jensen, Krzysztof Karczewski
 
 ## Release notes
+
+### 1.3.0
+
+* Added `context` to `Tracer.create` to allow disambiguation of tracers, if there are multiple for the same class.
 
 ### 1.2.1 - 1.2.2
 

--- a/README.md
+++ b/README.md
@@ -360,32 +360,31 @@ rather than an object reference.
 
 Use `Tracer.resetToDefaults()` to de-register all custom `toString` handlers.
 
-*** Disambiguation Of Trace Event Tracers
-* -------------------------------------
-*
-* Sometimes multiple tracers may exist for a single class (if multiple instances of the tracer are initiated).
-* In those cases, it may be necessary to be able disambiguate the tracer that the trace events came from.
-* This is solved by adding a `context` string to the `create` method. This context string is passed to
-* trace event consumers. Alternatively, trace event consumers can specify a regular expression to make sure
-* they only get the trace events for the specified tracer context(s).
-*
-* ```
-* // Declare 2 tracers.
-* val tracerMain = Tracer.Factory.create<SomeClass>(this::class, "main loop")
-* val tracerSec  = Tracer.Factory.create<SomeClass>(this::class, "secondary")
-*
-* // Declare a consumer for main loop events only.
-* val consumerSpecific = MyEventConsumerForSomeClass()
-* Tracer.addTraceEventConsumer(consumerSpecific, Regex("main.*"));
-*
-* // Declare a consumer for all events.
-* val consumerAll = MyEventConsumerForSomeClass()
-* Tracer.addTraceEventConsumer(consumerAll);
-* ```
-*
-* Note that only `GenericTraceEventConsumer`s are able to retrieve the context passed by the tracer (as it is
-* part of the `TraceEvent` data object. Specific `TraceEventConsumer`s (that implement the original tracer
-* interface), cannot access the context.
+### Using a `context` to disambiguate tracers with the same name
+
+Sometimes multiple tracers may exist for a single class (if multiple instances of the tracer are initiated).
+In those cases, it may be necessary to be able to disambiguate the tracer that the trace events came from.
+This is solved by adding a `context` string to the `create` method. This context string is passed to
+trace event consumers. Alternatively, trace event consumers can specify a regular expression to make sure
+they only get the trace events for the specified tracer context(s).
+
+```
+// Declare 2 tracers.
+val tracerMain = Tracer.Factory.create<SomeClass>(this::class, "main loop")
+val tracerSec  = Tracer.Factory.create<SomeClass>(this::class, "secondary")
+
+// Declare a consumer for events from any tracer starting with "main".
+val consumerMain = MyEventConsumerForSomeClass()
+Tracer.addTraceEventConsumer(consumerMain, Regex("main.*"));
+
+// Declare a consumer for all events (leaving out the regex).
+val consumerAll = MyEventConsumerForSomeClass()
+Tracer.addTraceEventConsumer(consumerAll);
+```
+
+Note that only `GenericTraceEventConsumer`s are able to retrieve the context string passed by the tracer (as it is
+part of the `TraceEvent` data object. Specific `TraceEventConsumer`s (that implement the original tracer
+interface), cannot access the context while processing events. 
 
 ### Advanced examples
 

--- a/memoization/pom.xml
+++ b/memoization/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.kotlin</groupId>
         <artifactId>kotlin-tools</artifactId>
-        <version>1.2.2</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>memoization</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>com.tomtom.kotlin</groupId>
     <artifactId>kotlin-tools</artifactId>
-    <version>1.2.2</version>
+    <version>1.3.0</version>
     <packaging>pom</packaging>
 
     <name>Kotlin Tools</name>

--- a/traceevents/pom.xml
+++ b/traceevents/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.kotlin</groupId>
         <artifactId>kotlin-tools</artifactId>
-        <version>1.2.2</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>traceevents</artifactId>

--- a/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceEvent.kt
+++ b/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceEvent.kt
@@ -25,6 +25,7 @@ import java.time.LocalDateTime
  * @param logLevel Log level (from [TraceLogLevel] annotation).
  * @param tracerClassName Class logging the event.
  * @param taggingClassName Tagging class passed to event, for convenience of debugging.
+ * @param context Disambiguation context for event tracers with the same tags.
  * @param interfaceName Interface name, derived from [TraceEventListener].
  * @param stackTraceHolder Throwable from which a stack trace can be produced. `null` when unavailable.
  * @param eventName Function name in interface, which represents the trace event name.
@@ -35,10 +36,11 @@ data class TraceEvent(
     val logLevel: LogLevel,
     val tracerClassName: String,
     val taggingClassName: String,
+    val context: String,
     val interfaceName: String,
     val stackTraceHolder: Throwable?,
     val eventName: String,
-    val args: Array<Any?>
+    val args: Array<Any?>,
 ) {
     /**
      * Need to override the `equals` and `hashCode` functions, as the class contains
@@ -54,6 +56,7 @@ data class TraceEvent(
         if (logLevel != other.logLevel) return false
         if (tracerClassName != other.tracerClassName) return false
         if (taggingClassName != other.taggingClassName) return false
+        if (context != other.context) return false
         if (interfaceName != other.interfaceName) return false
         if (stackTraceHolder != other.stackTraceHolder) return false
         if (eventName != other.eventName) return false
@@ -67,6 +70,7 @@ data class TraceEvent(
         result = 31 * result + logLevel.hashCode()
         result = 31 * result + tracerClassName.hashCode()
         result = 31 * result + taggingClassName.hashCode()
+        result = 31 * result + context.hashCode()
         result = 31 * result + interfaceName.hashCode()
         result = 31 * result + (stackTraceHolder?.hashCode() ?: 0)
         result = 31 * result + eventName.hashCode()

--- a/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceEventConsumerCollection.kt
+++ b/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceEventConsumerCollection.kt
@@ -33,24 +33,19 @@ class TraceEventConsumerCollection {
     }
 
     fun remove(traceEventConsumer: TraceEventConsumer, contextRegex: Regex? = null) {
-        if (contextRegex == null) {
-            // Remove all.
-        } else {
-            // Remove only for specific context regex.
-            traceEventsConsumersWithContext.remove(TraceEventConsumerWithContext(traceEventConsumer, contextRegex))
+        for (consumer in traceEventsConsumersWithContext.asIterable()
+            .filter {
+                it.traceEventConsumer == traceEventConsumer &&
+                        (contextRegex == null || it.contextRegex == contextRegex)
+            }) {
+            traceEventsConsumersWithContext.remove(consumer)
         }
     }
 
     fun all(contextRegex: Regex? = null): Iterable<TraceEventConsumer> {
-        if (contextRegex == null) {
-            return traceEventsConsumersWithContext.asIterable()
-                .map { it.traceEventConsumer }
-        } else {
-            // Return only for specific context regex.
-            return traceEventsConsumersWithContext.asIterable()
-                .filter { it.contextRegex == contextRegex }
-                .map { it.traceEventConsumer }
-        }
+        return traceEventsConsumersWithContext.asIterable()
+            .filter { contextRegex == null || it.contextRegex == contextRegex }
+            .map { it.traceEventConsumer }
     }
 
     suspend fun consumeTraceEvent(traceEvent: TraceEvent) {

--- a/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceLog.kt
+++ b/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceLog.kt
@@ -64,7 +64,7 @@ interface TraceLog {
             logLevel: LogLevel, tag: String, message: String, e: Throwable?
         ) =
             "[${LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME)}] $logLevel " +
-                "$tag: $message${e?.let { ", ${Tracer.formatThrowable(it, true)}" } ?: ""}"
+                    "$tag: $message${e?.let { ", ${Tracer.formatThrowable(it, true)}" } ?: ""}"
 
         internal var theLogger: Logger = DefaultLoggerToStdout
     }

--- a/traceevents/src/main/java/com/tomtom/kotlin/traceevents/Tracer.kt
+++ b/traceevents/src/main/java/com/tomtom/kotlin/traceevents/Tracer.kt
@@ -16,13 +16,8 @@
 package com.tomtom.kotlin.traceevents
 
 import com.tomtom.kotlin.traceevents.TraceLog.LogLevel
-import kotlinx.coroutines.CoroutineName
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.launch
 import java.io.PrintWriter
 import java.io.StringWriter
 import java.lang.reflect.InvocationHandler
@@ -127,10 +122,39 @@ import kotlin.reflect.jvm.jvmName
  *     }
  * }
  * ```
+ *
+ * DISAMBIGUATION OF TRACE EVENT TRACERS
+ * -------------------------------------
+ *
+ * Sometimes multiple tracers may exist for a single class (if multiple instances of the tracer are initiated).
+ * In those cases, it may be necessary to be able disambiguate the tracer that the trace events came from.
+ * This is solved by adding a `context` string to the `create` method. This context string is passed to
+ * trace event consumers. Alternatively, trace event consumers can specify a regular expression to make sure
+ * they only get the trace events for the specified tracer context(s).
+ *
+ * ```
+ * // Declare 2 tracers.
+ * val tracerMain = Tracer.Factory.create<SomeClass>(this::class, "main loop")
+ * val tracerSec  = Tracer.Factory.create<SomeClass>(this::class, "secondary")
+ *
+ * // Declare a consumer for main loop events only.
+ * val consumerSpecific = MyEventConsumerForSomeClass()
+ * Tracer.addTraceEventConsumer(consumerSpecific, Regex("main.*"));
+ *
+ * // Declare a consumer for all events.
+ * val consumerAll = MyEventConsumerForSomeClass()
+ * Tracer.addTraceEventConsumer(consumerAll);
+ * ```
+ *
+ * Note that only `GenericTraceEventConsumer`s are able to retrieve the context passed by the tracer (as it is
+ * part of the `TraceEvent` data object. Specific `TraceEventConsumer`s (that implement the original tracer
+ * interface), cannot access the context.
+ *
  */
 class Tracer private constructor(
     private val tracerClassName: String,
-    private val taggingClassName: String
+    private val taggingClassName: String,
+    private val context: String
 ) : InvocationHandler {
     val logTag = stripPackageFromClassName(tracerClassName)
 
@@ -146,14 +170,16 @@ class Tracer private constructor(
              *
              * @param taggingObject Owner object of the class using the event logger,
              *     specified as `this` from the companion object or an instance.
+             * @param context Optional string to disambiguate tracers with the same tagging object.
              * @return [TraceEventListener]-derived object, normally called the "tracer", to be used
              *     as `tracer.someEvent()`.
              */
-            inline fun <reified T : TraceEventListener> create(taggingObject: Any) =
+            inline fun <reified T : TraceEventListener> create(taggingObject: Any, context: String = "") =
                 createForListener_internal<T>(
                     tracerClassName = getTraceClassName_internal(Throwable()),
                     taggingClass = taggingObject::class,
-                    traceEventListener = T::class
+                    traceEventListener = T::class,
+                    context = context
                 )
 
             /**
@@ -164,12 +190,13 @@ class Tracer private constructor(
              * location.
              */
             @Suppress("NOTHING_TO_INLINE")
-            inline fun createLoggerOnly(taggingObject: Any) =
+            inline fun createLoggerOnly(taggingObject: Any, context: String = "") =
                 createForListenerAndLogger_internal<TraceEventListener>(
                     tracerClassName = getTraceClassName_internal(Throwable()),
                     taggingClass = taggingObject::class,
                     traceEventListener = TraceEventListener::class,
-                    isLoggerOnly = true
+                    isLoggerOnly = true,
+                    context = context
                 )
 
             /**
@@ -186,11 +213,14 @@ class Tracer private constructor(
             fun <T : TraceEventListener> createForListener_internal(
                 tracerClassName: String,
                 taggingClass: KClass<*>,
-                traceEventListener: KClass<out TraceEventListener>
+                traceEventListener: KClass<out TraceEventListener>,
+                context: String
             ): T = createForListenerAndLogger_internal<T>(
                 tracerClassName = tracerClassName,
                 taggingClass = taggingClass,
-                traceEventListener = traceEventListener
+                traceEventListener = traceEventListener,
+                isLoggerOnly = false,
+                context = context
             )
 
             /**
@@ -205,7 +235,8 @@ class Tracer private constructor(
                 tracerClassName: String,
                 taggingClass: KClass<*>,
                 traceEventListener: KClass<out TraceEventListener>,
-                isLoggerOnly: Boolean = false
+                isLoggerOnly: Boolean,
+                context: String
             ): T {
                 require(isLoggerOnly || traceEventListener != TraceEventListener::class) {
                     "Derive an interface from TraceEventListener, or use createLoggerOnly()"
@@ -222,7 +253,8 @@ class Tracer private constructor(
                     arrayOf<Class<*>?>(traceEventListener.java),
                     Tracer(
                         tracerClassName = tracerClassName,
-                        taggingClassName = taggingClassTopLevel.jvmName
+                        taggingClassName = taggingClassTopLevel.jvmName,
+                        context = context
                     )
                 ) as T
             }
@@ -269,6 +301,7 @@ class Tracer private constructor(
             logLevel = logLevelAnnotation,
             tracerClassName = tracerClassName,
             taggingClassName = taggingClassName,
+            context = context,
             interfaceName = method.declaringClass.name,
             stackTraceHolder = Throwable(),
             eventName = method.name,
@@ -387,8 +420,8 @@ class Tracer private constructor(
                 LogLevel.WARN,
                 logTag,
                 "Trace event channel is full, " +
-                    "nrLostTraceEventsSinceLastMsg=$nrLostTraceEventsSinceLastMsg, " +
-                    "nrLostTraceEventsTotal=$nrLostTraceEventsTotal"
+                        "nrLostTraceEventsSinceLastMsg=$nrLostTraceEventsSinceLastMsg, " +
+                        "nrLostTraceEventsTotal=$nrLostTraceEventsTotal"
             )
             nrLostTraceEventsSinceLastMsg = 0L
             timeLastLostTraceEvent = now
@@ -413,7 +446,6 @@ class Tracer private constructor(
                     // Signal the listener an incorrect signature was found.
                     incorrectLogSignatureFound()
                 }
-            } else {
             }
         }
     }
@@ -505,9 +537,13 @@ class Tracer private constructor(
          * Add a trace event consumer for trace processing. This also starts the event processor
          * if it wasn't started already. (No need for the processor to run if there are no
          * consumers.)
+         *
+         * @param traceEventConsumer Trace event consumer to receive trace events.
+         * @param contextRegex Regular expression to filter trace events. Only events from tracers with a context
+         * that matches the regular expression will be received. If omitted, or `null`, all events will be received.
          */
-        fun addTraceEventConsumer(traceEventConsumer: TraceEventConsumer) {
-            traceEventConsumers.add(traceEventConsumer)
+        fun addTraceEventConsumer(traceEventConsumer: TraceEventConsumer, contextRegex: Regex? = null) {
+            traceEventConsumers.add(traceEventConsumer, contextRegex)
 
             /**
              * The event processor is started only when the first consumer is registered and stays
@@ -524,15 +560,22 @@ class Tracer private constructor(
         /**
          * Remove a trace event consumer. The event processor should not be stopped if there are
          * no consumers left, because it holds the event queue and you may lose events then.
+         *
+         * @param traceEventConsumer Trace event consumer to remove.
+         * @param contextRegex If this is `null`, all trace event consumers for the same tracers will be removed.
+         * Otherwise only the specific trace event consumer for that regular expression is removed.
          */
-        fun removeTraceEventConsumer(traceEventConsumer: TraceEventConsumer) {
-            traceEventConsumers.remove(traceEventConsumer)
+        fun removeTraceEventConsumer(traceEventConsumer: TraceEventConsumer, contextRegex: Regex? = null) {
+            traceEventConsumers.remove(traceEventConsumer, contextRegex)
         }
 
         /**
          * Remove all event consumers.
+         *
+         * @param contextRegex If this is `null`, all trace event consumers will be removed. Otherwise,
+         * tarce event consumer for specific contexts are removed.
          */
-        fun removeAllTraceEventConsumers() {
+        fun removeAllTraceEventConsumers(contextRegex: Regex? = null) {
             traceEventConsumers.all().asSequence().forEach { removeTraceEventConsumer(it) }
         }
 
@@ -621,20 +664,20 @@ class Tracer private constructor(
             if (args == null || args.isEmpty() ||
                 args[0] == null || args[0]!!::class != String::class ||
                 (args.size == 2 &&
-                    args[1] != null && !args[1]!!::class.isSubclassOf(Throwable::class)) ||
+                        args[1] != null && !args[1]!!::class.isSubclassOf(Throwable::class)) ||
                 args.size > 2
             ) {
                 TraceLog.log(
                     LogLevel.ERROR,
                     TAG,
                     "Incorrect log call, expected arguments (String, Throwable), " +
-                        "args=${
-                            args?.joinToString {
-                                it?.let {
-                                    it.javaClass.simpleName + ":" + it.toString()
-                                } ?: "null"
-                            }
-                        }"
+                            "args=${
+                                args?.joinToString {
+                                    it?.let {
+                                        it.javaClass.simpleName + ":" + it.toString()
+                                    } ?: "null"
+                                }
+                            }"
                 )
                 return false
             }
@@ -791,7 +834,7 @@ class Tracer private constructor(
                  */
                 val item = stack[i + 2]
                 "${item.fileName ?: "(unknown)"}:${item.methodName}(" +
-                    "${if (item.lineNumber >= 0) item.lineNumber.toString() else "unknown"})"
+                        "${if (item.lineNumber >= 0) item.lineNumber.toString() else "unknown"})"
             } else {
 
                 // This shouldn't happen, but we certainly shouldn't throw here.

--- a/traceevents/src/main/java/com/tomtom/kotlin/traceevents/Tracer.kt
+++ b/traceevents/src/main/java/com/tomtom/kotlin/traceevents/Tracer.kt
@@ -573,10 +573,10 @@ class Tracer private constructor(
          * Remove all event consumers.
          *
          * @param contextRegex If this is `null`, all trace event consumers will be removed. Otherwise,
-         * tarce event consumer for specific contexts are removed.
+         * trace event consumer for specific contexts are removed.
          */
         fun removeAllTraceEventConsumers(contextRegex: Regex? = null) {
-            traceEventConsumers.all().asSequence().forEach { removeTraceEventConsumer(it) }
+            traceEventConsumers.all().asSequence().forEach { removeTraceEventConsumer(it, contextRegex) }
         }
 
         /**

--- a/traceevents/src/test/java/com/tomtom/kotlin/traceevents/AnnotationsTest.kt
+++ b/traceevents/src/test/java/com/tomtom/kotlin/traceevents/AnnotationsTest.kt
@@ -45,7 +45,7 @@ class AnnotationsTest {
 
     @Before
     fun setUp() {
-        TraceLog.setLogger()
+        setUpTracerTest()
     }
 
     @Test

--- a/traceevents/src/test/java/com/tomtom/kotlin/traceevents/LogInstanceTest.kt
+++ b/traceevents/src/test/java/com/tomtom/kotlin/traceevents/LogInstanceTest.kt
@@ -23,7 +23,7 @@ class LogInstanceTest {
 
     @Before
     fun setUp() {
-        TraceLog.setLogger()
+        setUpTracerTest()
     }
 
     interface TestEvents : TraceEventListener {

--- a/traceevents/src/test/java/com/tomtom/kotlin/traceevents/LogOtherClassInstanceTest.kt
+++ b/traceevents/src/test/java/com/tomtom/kotlin/traceevents/LogOtherClassInstanceTest.kt
@@ -23,7 +23,7 @@ class LogOtherClassInstanceTest {
 
     @Before
     fun setUp() {
-        TraceLog.setLogger()
+        setUpTracerTest()
     }
 
     @Test

--- a/traceevents/src/test/java/com/tomtom/kotlin/traceevents/LogOtherClassTest.kt
+++ b/traceevents/src/test/java/com/tomtom/kotlin/traceevents/LogOtherClassTest.kt
@@ -24,7 +24,7 @@ class LogOtherClassTest {
 
     @Before
     fun setUp() {
-        TraceLog.setLogger()
+        setUpTracerTest()
     }
 
     @Test

--- a/traceevents/src/test/java/com/tomtom/kotlin/traceevents/LogTest.kt
+++ b/traceevents/src/test/java/com/tomtom/kotlin/traceevents/LogTest.kt
@@ -17,6 +17,9 @@ package com.tomtom.kotlin.traceevents
 
 import com.tomtom.kotlin.traceevents.TraceLog.LogLevel
 import com.tomtom.kotlin.traceevents.TraceLog.Logger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -73,7 +76,7 @@ class LogTest {
 
     @Before
     fun setUp() {
-        TraceLog.setLogger()
+        setUpTracerTest()
     }
 
     @Test
@@ -196,12 +199,12 @@ class LogTest {
         // Cut off just enough to NOT include line numbers of source code as they may change.
         val prefix =
             "$TIME DEBUG LogTest: test1, java.lang.IllegalStateException: error1\n" +
-                "\tat com.tomtom.kotlin.traceevents.LogTest\$log message with exception to stdout\$actual\$1.invoke(LogTest.kt:"
+                    "\tat com.tomtom.kotlin.traceevents.LogTest\$log message with exception to stdout\$actual\$1.invoke(LogTest.kt:"
         val suffix =
             ")\n" +
-                "Caused by: java.lang.NullPointerException\n" +
-                "\t... $NUMBER more\n" +
-                "\n"
+                    "Caused by: java.lang.NullPointerException\n" +
+                    "\t... $NUMBER more\n" +
+                    "\n"
 
         assertTrue(actual.startsWith(prefix))
         assertTrue(replaceNumber(actual, NUMBER).endsWith(suffix))
@@ -247,13 +250,13 @@ class LogTest {
         // Cut off just enough to NOT include line numbers of source code as they may change.
         val prefix =
             "$TIME DEBUG LogTest: event=withExceptionStackTrace(java.lang.IllegalStateException: error1), taggingClass=LogTest\n" +
-                "java.lang.IllegalStateException: error1\n" +
-                "\tat com.tomtom.kotlin.traceevents.LogTest\$log event with exception to stdout with stacktrace\$actual\$1.invoke(LogTest.kt:"
+                    "java.lang.IllegalStateException: error1\n" +
+                    "\tat com.tomtom.kotlin.traceevents.LogTest\$log event with exception to stdout with stacktrace\$actual\$1.invoke(LogTest.kt:"
         val suffix =
             ")\n" +
-                "Caused by: java.lang.NullPointerException\n" +
-                "\t... $NUMBER more\n" +
-                "\n"
+                    "Caused by: java.lang.NullPointerException\n" +
+                    "\t... $NUMBER more\n" +
+                    "\n"
 
         assertTrue(actual.startsWith(prefix))
         assertTrue(replaceNumber(actual, NUMBER).endsWith(suffix))

--- a/traceevents/src/test/java/com/tomtom/kotlin/traceevents/TestUtils.kt
+++ b/traceevents/src/test/java/com/tomtom/kotlin/traceevents/TestUtils.kt
@@ -24,18 +24,22 @@ import kotlin.reflect.jvm.jvmName
 /**
  * Utility function to check if a trace events matches the given parameters.
  */
+val CONTEXT_REGEX_ANY = Regex(".*");
+
 fun MockKMatcherScope.traceEq(
+    contextRegex: Regex,
     logLevel: LogLevel,
     functionName: String,
     vararg args: Any
 ) =
     match<TraceEvent> { traceEvent ->
         traceEvent.logLevel == logLevel &&
-            traceEvent.taggingClassName == TracerTest::class.jvmName &&
-            traceEvent.interfaceName == TracerTest.MyEvents::class.jvmName &&
-            traceEvent.eventName == functionName &&
-            traceEvent.args.map { it?.javaClass } == args.map { it.javaClass } &&
-            traceEvent.args.contentDeepEquals(args)
+                traceEvent.taggingClassName == TracerTest::class.jvmName &&
+                contextRegex.matches(traceEvent.context) &&
+                traceEvent.interfaceName == TracerTest.MyEvents::class.jvmName &&
+                traceEvent.eventName == functionName &&
+                traceEvent.args.map { it?.javaClass } == args.map { it.javaClass } &&
+                traceEvent.args.contentDeepEquals(args)
     }
 
 /**

--- a/traceevents/src/test/java/com/tomtom/kotlin/traceevents/TestUtils.kt
+++ b/traceevents/src/test/java/com/tomtom/kotlin/traceevents/TestUtils.kt
@@ -17,6 +17,9 @@ package com.tomtom.kotlin.traceevents
 
 import com.tomtom.kotlin.traceevents.TraceLog.LogLevel
 import io.mockk.MockKMatcherScope
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
 import kotlin.reflect.jvm.jvmName
@@ -24,10 +27,8 @@ import kotlin.reflect.jvm.jvmName
 /**
  * Utility function to check if a trace events matches the given parameters.
  */
-val CONTEXT_REGEX_ANY = Regex(".*");
-
 fun MockKMatcherScope.traceEq(
-    contextRegex: Regex,
+    context: String,
     logLevel: LogLevel,
     functionName: String,
     vararg args: Any
@@ -35,7 +36,7 @@ fun MockKMatcherScope.traceEq(
     match<TraceEvent> { traceEvent ->
         traceEvent.logLevel == logLevel &&
                 traceEvent.taggingClassName == TracerTest::class.jvmName &&
-                contextRegex.matches(traceEvent.context) &&
+                traceEvent.context == context &&
                 traceEvent.interfaceName == TracerTest.MyEvents::class.jvmName &&
                 traceEvent.eventName == functionName &&
                 traceEvent.args.map { it?.javaClass } == args.map { it.javaClass } &&
@@ -81,6 +82,25 @@ fun replaceNumber(msg: String?, replaceWith: String) = msg?.replace(
     "\\b[0-9]+\\b".toRegex(RegexOption.MULTILINE),
     replaceWith
 ) ?: ""
+
+fun setUpTracerTest() {
+
+    /**
+     * For every test case remove all consumer, cancel the processor (which will be restarted
+     * at next add consumer) and flush all events. Make sure that when the processor starts,
+     * it starts on the thread of this test.
+     */
+    runBlocking {
+        TraceLog.setLogger()
+        Tracer.eventProcessorScope = CoroutineScope(Dispatchers.Unconfined)
+        Tracer.setTraceEventLoggingMode(Tracer.Companion.LoggingMode.SYNC)
+        Tracer.enableTraceEventLogging(true)
+        Tracer.removeAllTraceEventConsumers()
+        Tracer.cancelAndJoinEventProcessor()
+        Tracer.flushTraceEvents()
+        Tracer.resetToDefaults()
+    }
+}
 
 /**
  * Replacements for times and numbers.

--- a/traceevents/src/test/java/com/tomtom/kotlin/traceevents/TracerTest.kt
+++ b/traceevents/src/test/java/com/tomtom/kotlin/traceevents/TracerTest.kt
@@ -128,9 +128,9 @@ class TracerTest {
 
         // THEN
         coVerifySequence {
-            consumer.consumeTraceEvent(traceEq(LogLevel.DEBUG, "eventNoArgs"))
-            consumer.consumeTraceEvent(traceEq(LogLevel.DEBUG, "eventString", "xyz"))
-            consumer.consumeTraceEvent(traceEq(LogLevel.ERROR, "eventIntsString", 10, 20, "abc"))
+            consumer.consumeTraceEvent(traceEq(CONTEXT_REGEX_ANY, LogLevel.DEBUG, "eventNoArgs"))
+            consumer.consumeTraceEvent(traceEq(CONTEXT_REGEX_ANY, LogLevel.DEBUG, "eventString", "xyz"))
+            consumer.consumeTraceEvent(traceEq(CONTEXT_REGEX_ANY, LogLevel.ERROR, "eventIntsString", 10, 20, "abc"))
         }
     }
 

--- a/uid/pom.xml
+++ b/uid/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.kotlin</groupId>
         <artifactId>kotlin-tools</artifactId>
-        <version>1.2.2</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>uid</artifactId>


### PR DESCRIPTION
* Added `context` to `Tracer.create` to allow disambiguation of tracers, if there are multiple for the same class.
* Fixed setup error in unit tests.