### PR TITLE
Add trace event context to logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,6 +533,10 @@ Contributors: Timon Kanters, Jeroen Erik Jensen, Krzysztof Karczewski
 
 ## Release notes
 
+### 1.3.1
+
+* Added `context` to logging, if context is not empty.
+
 ### 1.3.0
 
 * Added `context` to `Tracer.create` to allow disambiguation of tracers, if there are multiple for the same class.

--- a/memoization/pom.xml
+++ b/memoization/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.kotlin</groupId>
         <artifactId>kotlin-tools</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1</version>
     </parent>
 
     <artifactId>memoization</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>com.tomtom.kotlin</groupId>
     <artifactId>kotlin-tools</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.1</version>
     <packaging>pom</packaging>
 
     <name>Kotlin Tools</name>

--- a/traceevents/pom.xml
+++ b/traceevents/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.kotlin</groupId>
         <artifactId>kotlin-tools</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1</version>
     </parent>
 
     <artifactId>traceevents</artifactId>

--- a/traceevents/src/main/java/com/tomtom/kotlin/traceevents/Tracer.kt
+++ b/traceevents/src/main/java/com/tomtom/kotlin/traceevents/Tracer.kt
@@ -772,6 +772,11 @@ class Tracer private constructor(
                 sb.append(", eventInterface=${traceEvent.interfaceName}")
             }
 
+            // Context.
+            if (traceEvent.context.isNotEmpty()) {
+                sb.append(", context=${traceEvent.context}")
+            }
+
             // Stack trace for last parameter, if it's an exception.
             if (includeExceptionStackTrace && !traceEvent.args.isEmpty()) {
                 (traceEvent.args.last() as? Throwable)?.let {

--- a/traceevents/src/test/java/com/tomtom/kotlin/traceevents/LogContextTest.kt
+++ b/traceevents/src/test/java/com/tomtom/kotlin/traceevents/LogContextTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2012-2021, TomTom (http://tomtom.com).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tomtom.kotlin.traceevents
+
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class LogContextTest {
+
+    @Before
+    fun setUp() {
+        setUpTracerTest()
+    }
+
+    interface TestEvents : TraceEventListener {
+        fun someEvent(message: String)
+    }
+
+    @Test
+    fun `tracer declared in companion object`() {
+        val actual = captureStdoutReplaceTime(TIME) {
+            tracerFromCompanionObject.someEvent("test1")
+        }
+        val expected =
+            "$TIME DEBUG LogContextTest: event=someEvent(test1), context=$CONTEXT_VALUE\n"
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `tracer declared in instance`() {
+        val tracerFromInstance = Tracer.Factory.create<TestEvents>(this, context = CONTEXT_VALUE)
+        val actual = captureStdoutReplaceTime(TIME) {
+            tracerFromInstance.someEvent("test2")
+        }
+        val expected =
+            "$TIME DEBUG LogContextTest: event=someEvent(test2), context=$CONTEXT_VALUE\n"
+        assertEquals(expected, actual)
+    }
+
+    companion object {
+        private const val CONTEXT_VALUE = "42"
+
+        val tracerFromCompanionObject = Tracer.Factory.create<TestEvents>(
+                this,
+                context = CONTEXT_VALUE
+        )
+    }
+}

--- a/uid/pom.xml
+++ b/uid/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.kotlin</groupId>
         <artifactId>kotlin-tools</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1</version>
     </parent>
 
     <artifactId>uid</artifactId>


### PR DESCRIPTION
Add trace event `context` to logging if it is not empty. Bump version to 1.3.1.