### PR TITLE
Add per-thread context to trace events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,5 @@ buildNumber.properties
 .mvn/wrapper/maven-wrapper.jar
 
 # End of https://www.toptal.com/developers/gitignore/api/maven,kotlin,intellij
+.idea/
+.gradle/

--- a/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceContext.kt
+++ b/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceContext.kt
@@ -1,0 +1,53 @@
+package com.tomtom.kotlin.traceevents
+
+
+/**
+ * ThreadLocal trace context, basically copied from the basic MDC implementation
+ */
+object TraceContext {
+
+    private val inheritableThreadLocal: InheritableThreadLocal<MutableMap<String, Any>?> = object : InheritableThreadLocal<MutableMap<String, Any>?>() {
+        fun childValue(parentValue: Map<String, Any>?): Map<String, Any>? {
+            return parentValue?.let { HashMap(it) }
+        }
+    }
+
+    fun put(key: String, value: Any) {
+        var map = inheritableThreadLocal?.get()
+        if (map == null) {
+            map = HashMap()
+            inheritableThreadLocal.set(map)
+        }
+        map[key] = value
+    }
+
+    fun get(key: String): Any? {
+        val map = inheritableThreadLocal?.get()
+        return map?.get(key)
+    }
+
+    fun remove(key: String) {
+        val map = inheritableThreadLocal?.get()
+        map?.remove(key)
+    }
+
+    fun clear() {
+        val map = inheritableThreadLocal.get()
+        map?.clear()
+        inheritableThreadLocal.remove()
+    }
+
+    val keys: Set<Any>?
+        get() {
+            val map = inheritableThreadLocal.get()
+            return map?.keys
+        }
+
+    fun getCopyOfContextMap(): Map<String, Any>? {
+        return inheritableThreadLocal.get()?.let { HashMap(it) }
+    }
+
+    fun setContextMap(contextMap: Map<String, String>) {
+        inheritableThreadLocal.set(HashMap(contextMap))
+    }
+}

--- a/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceDiagnosticContext.kt
+++ b/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceDiagnosticContext.kt
@@ -4,7 +4,7 @@ package com.tomtom.kotlin.traceevents
 /**
  * ThreadLocal trace context, basically copied from the basic MDC implementation
  */
-object TraceContext {
+object TraceDiagnosticContext {
 
     private val inheritableThreadLocal: InheritableThreadLocal<MutableMap<String, Any>?> = object : InheritableThreadLocal<MutableMap<String, Any>?>() {
         fun childValue(parentValue: Map<String, Any>?): Map<String, Any>? {

--- a/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceEvent.kt
+++ b/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceEvent.kt
@@ -41,6 +41,7 @@ data class TraceEvent(
     val stackTraceHolder: Throwable?,
     val eventName: String,
     val args: Array<Any?>,
+    val eventDiagnosticContext: Map<String, Any?>? = emptyMap()
 ) {
     /**
      * Need to override the `equals` and `hashCode` functions, as the class contains
@@ -52,6 +53,7 @@ data class TraceEvent(
 
         other as TraceEvent
 
+        if (eventDiagnosticContext != other.eventDiagnosticContext) return false
         if (dateTime != other.dateTime) return false
         if (logLevel != other.logLevel) return false
         if (tracerClassName != other.tracerClassName) return false
@@ -75,6 +77,7 @@ data class TraceEvent(
         result = 31 * result + (stackTraceHolder?.hashCode() ?: 0)
         result = 31 * result + eventName.hashCode()
         result = 31 * result + args.contentDeepHashCode()
+        result = 31 * result + eventDiagnosticContext.hashCode()
         return result
     }
 }

--- a/traceevents/src/main/java/com/tomtom/kotlin/traceevents/Tracer.kt
+++ b/traceevents/src/main/java/com/tomtom/kotlin/traceevents/Tracer.kt
@@ -305,7 +305,8 @@ class Tracer private constructor(
             interfaceName = method.declaringClass.name,
             stackTraceHolder = Throwable(),
             eventName = method.name,
-            args = args ?: arrayOf<Any?>()
+            args = args ?: arrayOf(),
+            eventDiagnosticContext = TraceContext.getCopyOfContextMap()
         )
 
         /**
@@ -775,6 +776,11 @@ class Tracer private constructor(
             // Context.
             if (traceEvent.context.isNotEmpty()) {
                 sb.append(", context=${traceEvent.context}")
+            }
+
+            // Diagnostics
+            if (traceEvent.eventDiagnosticContext != null) {
+                sb.append(", diagnostics=${traceEvent.eventDiagnosticContext}")
             }
 
             // Stack trace for last parameter, if it's an exception.

--- a/traceevents/src/main/java/com/tomtom/kotlin/traceevents/Tracer.kt
+++ b/traceevents/src/main/java/com/tomtom/kotlin/traceevents/Tracer.kt
@@ -306,7 +306,7 @@ class Tracer private constructor(
             stackTraceHolder = Throwable(),
             eventName = method.name,
             args = args ?: arrayOf(),
-            eventDiagnosticContext = TraceContext.getCopyOfContextMap()
+            eventDiagnosticContext = TraceDiagnosticContext.getCopyOfContextMap()
         )
 
         /**

--- a/traceevents/src/test/java/com/tomtom/kotlin/traceevents/TestUtils.kt
+++ b/traceevents/src/test/java/com/tomtom/kotlin/traceevents/TestUtils.kt
@@ -29,18 +29,21 @@ import kotlin.reflect.jvm.jvmName
  */
 fun MockKMatcherScope.traceEq(
     context: String,
+    diagnosticContext: Map<String, Any?>? = null,
     logLevel: LogLevel,
     functionName: String,
     vararg args: Any
 ) =
     match<TraceEvent> { traceEvent ->
+
         traceEvent.logLevel == logLevel &&
                 traceEvent.taggingClassName == TracerTest::class.jvmName &&
                 traceEvent.context == context &&
                 traceEvent.interfaceName == TracerTest.MyEvents::class.jvmName &&
                 traceEvent.eventName == functionName &&
                 traceEvent.args.map { it?.javaClass } == args.map { it.javaClass } &&
-                traceEvent.args.contentDeepEquals(args)
+                traceEvent.args.contentDeepEquals(args) &&
+                traceEvent.eventDiagnosticContext == diagnosticContext
     }
 
 /**

--- a/traceevents/src/test/java/com/tomtom/kotlin/traceevents/TracerTest.kt
+++ b/traceevents/src/test/java/com/tomtom/kotlin/traceevents/TracerTest.kt
@@ -16,9 +16,11 @@
 package com.tomtom.kotlin.traceevents
 
 import com.tomtom.kotlin.traceevents.TraceLog.LogLevel
-import io.mockk.*
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
+import io.mockk.coVerify
+import io.mockk.coVerifySequence
+import io.mockk.spyk
+import io.mockk.verify
+import io.mockk.verifySequence
 import kotlinx.coroutines.runBlocking
 import nl.jqno.equalsverifier.EqualsVerifier
 import org.junit.Before

--- a/traceevents/src/test/java/com/tomtom/kotlin/traceevents/TracerTest.kt
+++ b/traceevents/src/test/java/com/tomtom/kotlin/traceevents/TracerTest.kt
@@ -218,7 +218,7 @@ class TracerTest {
 
         // WHEN
         sut.eventNoArgs()
-        TraceContext.put("id", 123123)
+        TraceDiagnosticContext.put("id", 123123)
         sut.eventNoArgs()
 
 

--- a/traceevents/src/test/java/com/tomtom/kotlin/traceevents/TracerTest.kt
+++ b/traceevents/src/test/java/com/tomtom/kotlin/traceevents/TracerTest.kt
@@ -170,9 +170,9 @@ class TracerTest {
 
         // THEN
         coVerifySequence {
-            consumer.consumeTraceEvent(traceEq("", LogLevel.DEBUG, "eventNoArgs"))
-            consumer.consumeTraceEvent(traceEq("", LogLevel.DEBUG, "eventString", "xyz"))
-            consumer.consumeTraceEvent(traceEq("", LogLevel.ERROR, "eventIntsString", 10, 20, "abc"))
+            consumer.consumeTraceEvent(traceEq("",null, LogLevel.DEBUG, "eventNoArgs"))
+            consumer.consumeTraceEvent(traceEq("",null, LogLevel.DEBUG, "eventString", "xyz"))
+            consumer.consumeTraceEvent(traceEq("", null, LogLevel.ERROR, "eventIntsString", 10, 20, "abc"))
         }
     }
 
@@ -189,7 +189,7 @@ class TracerTest {
 
         // THEN
         coVerifySequence {
-            consumer.consumeTraceEvent(traceEq("the main tracer", LogLevel.DEBUG, "eventString", "xyz"))
+            consumer.consumeTraceEvent(traceEq("the main tracer", null, LogLevel.DEBUG, "eventString", "xyz"))
         }
     }
 
@@ -207,6 +207,25 @@ class TracerTest {
         // THEN
         coVerify(exactly = 0) {
             consumer.consumeTraceEvent(any())
+        }
+    }
+
+    @Test
+    fun `generic consumer with diagnostic context`() {
+        // GIVEN
+        val consumer = spyk(TracerTest.GenericConsumer())
+        Tracer.addTraceEventConsumer(consumer)
+
+        // WHEN
+        sut.eventNoArgs()
+        TraceContext.put("id", 123123)
+        sut.eventNoArgs()
+
+
+        // THEN
+        coVerifySequence {
+            consumer.consumeTraceEvent(traceEq("", null, LogLevel.DEBUG, "eventNoArgs"))
+            consumer.consumeTraceEvent(traceEq("", HashMap(mapOf("id" to 123123)), LogLevel.DEBUG, "eventNoArgs"))
         }
     }
 


### PR DESCRIPTION
Add the ability to add per-thread context or diagnostics info to trace events.