### PR TITLE
Added threadlocal diagnostic context to trace events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-# Created by https://www.toptal.com/developers/gitignore/api/maven,kotlin,intellij
-# Edit at https://www.toptal.com/developers/gitignore?templates=maven,kotlin,intellij
+# Created by https://www.toptal.com/developers/gitignore/api/maven,kotlin,intellij,gradle
+# Edit at https://www.toptal.com/developers/gitignore?templates=maven,kotlin,intellij,gradle
 
 ### Intellij ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
@@ -11,6 +11,9 @@
 .idea/**/usage.statistics.xml
 .idea/**/dictionaries
 .idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
 
 # Generated files
 .idea/**/contentModel.xml
@@ -32,14 +35,14 @@
 # When using Gradle or Maven with auto-import, you should exclude module files,
 # since they will be recreated, and may cause churn.  Uncomment if using
 # auto-import.
-.idea/artifacts
-.idea/compiler.xml
-.idea/jarRepositories.xml
-.idea/modules.xml
-.idea/*.iml
-.idea/modules
-*.iml
-*.ipr
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
 
 # CMake
 cmake-build-*/
@@ -142,4 +145,34 @@ buildNumber.properties
 # https://github.com/takari/maven-wrapper#usage-without-binary-jar
 .mvn/wrapper/maven-wrapper.jar
 
-# End of https://www.toptal.com/developers/gitignore/api/maven,kotlin,intellij
+### Maven Patch ###
+# Eclipse m2e generated files
+# Eclipse Core
+.project
+# JDT-specific (Eclipse Java Development Tools)
+.classpath
+
+### Gradle ###
+.gradle
+build/
+
+# Ignore Gradle GUI config
+gradle-app.setting
+
+# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
+!gradle-wrapper.jar
+
+# Cache of project
+.gradletasknamecache
+
+# # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
+# gradle/wrapper/gradle-wrapper.properties
+
+### Gradle Patch ###
+**/build/
+
+# Eclipse Gradle plugin generated files
+# Eclipse Core
+# JDT-specific (Eclipse Java Development Tools)
+
+# End of https://www.toptal.com/developers/gitignore/api/maven,kotlin,intellij,gradle

--- a/README.md
+++ b/README.md
@@ -403,8 +403,11 @@ Here's an example of storing additional context in trace events.
 TraceDiagnosticContext.put("currentRequest", myRequest)
 ```
 
-This would add a map with `{currentRequest: myRequest}` to each trace event generated from the same thread
-as this call to `put` was on. 
+This would add a map called `traceDiagnosticContext` to the event with value `{"currentRequest": "myRequest"}` 
+to each trace event generated from the same thread as this call to `put` was on. 
+
+The map `traceDiagnosticContext` is available for `GenericTraceEventConsumer`s only and it is `null` when
+no threadlocal data was stored, or a non-empty map when data was stored.
 
 This is particularly useful for adding information that isn't necessarily available at the location where the
 trace event is generated. Without this feature, such events would require more parameters, just for the sake
@@ -476,11 +479,7 @@ eventSkipToNext(traceDiagnosticContext = {"songName": "Bohemian Rhapsody"})
 eventPlaySong(songName = "Breakfast in America", traceDiagnosticContext = {"songName": "Bohemian Rhapsody"})
 ```
 
-Now it becomes trivial to see that "Bohemian Rhapsody" was skipped to arrive at "Breakfast in America'.
-
-Note that only `GenericTraceEventConsumer`s are able to retrieve the context map passed by the tracer (as it is part of
-the `TraceEvent` data object. Specific `TraceEventConsumer`s (that implement the original tracer interface), cannot
-access the context while processing events.
+Now it becomes trivial to see that "Bohemian Rhapsody" was skipped to arrive at "Breakfast in America".
 
 ### Advanced examples
 

--- a/README.md
+++ b/README.md
@@ -548,14 +548,14 @@ And then choose the pre-defined style `Kotlin Style Guide`. Voila!
 
 Author: Rijn Buve
 
-Contributors: Timon Kanters, Jeroen Erik Jensen, Krzysztof Karczewski
+Contributors: Timon Kanters, Jeroen Erik Jensen, Krzysztof Karczewski, Chris Owen
 
 ## Release notes
 
 ### 1.5.0
 
 * Added ability to store threadlocal diagnostic context to trace events. This context can be processed
-  by `GenericTraceEventConsumer`s.
+  by `GenericTraceEventConsumer`s. Initial idea by Chris Owen.
 
 ### 1.4.1
 

--- a/README.md
+++ b/README.md
@@ -435,12 +435,12 @@ different methods:
 ```
 fun playRandomSong() {
     val song = chooseRandomSong(allSongs)
-    eventPlaySong(song.name) // <-- this generates an event with the current song name
+    eventPlaySong(song.name)    // <-- generate an event with the current song name
     startPlaying(song)
 }
 
 fun userPressedNext() {
-    eventSkipToNext() // <-- this generates the sip to next event
+    eventSkipToNext()           // <-- generate the sip to next event
     playRandomSong()
 }
 ```
@@ -464,8 +464,8 @@ for the implementation of `playRandomSong`:
 ```
 fun playRandomSong() {
     val song = chooseRandomSong(allSongs)
-    TraceDiagnosticContext.put("songName", song.name) // <-- and the new song name as 'current'
-    eventPlaySong(song.name) // <-- this generates an event with the current song name
+    TraceDiagnosticContext.put("songName", song.name) // <-- store the song name in (threadlocal) data
+    eventPlaySong(song.name)                          // <-- generate an event with the current song name
     startPlaying(song)
 }
 ```
@@ -479,7 +479,8 @@ eventSkipToNext(traceDiagnosticContext = {"songName": "Bohemian Rhapsody"})
 eventPlaySong(songName = "Breakfast in America", traceDiagnosticContext = {"songName": "Bohemian Rhapsody"})
 ```
 
-Now it becomes trivial to see that "Bohemian Rhapsody" was skipped to arrive at "Breakfast in America".
+Now it becomes trivial to see that "Bohemian Rhapsody" was skipped, and that "Breakfast in America" was played
+before that.
 
 ### Advanced examples
 

--- a/README.md
+++ b/README.md
@@ -382,17 +382,36 @@ val consumerAll = MyEventConsumerForSomeClass()
 Tracer.addTraceEventConsumer(consumerAll);
 ```
 
-Note that only `GenericTraceEventConsumer`s are able to retrieve the context string passed by the tracer (as it is
-part of the `TraceEvent` data object. Specific `TraceEventConsumer`s (that implement the original tracer
-interface), cannot access the context while processing events. 
+Note that only `GenericTraceEventConsumer`s are able to retrieve the context string passed by the tracer (as it is part
+of the `TraceEvent` data object. Specific `TraceEventConsumer`s (that implement the original tracer interface), cannot
+access the context while processing events.
+
+### Adding threadlocal diagnostic context to trace events
+
+Similar to adding a regular context string, you can also add more advanced context to trace events that is stored per
+thread that the tracer is being used on to generate events. This is done by adding elements to
+the `TraceDiagnosticContext` map, which is stored as a threadlocal object.
+
+Here's an example of storing additional context in trace events.
+
+```
+TraceDiagnosticContext.put("currentRequest", myRequest)
+```
+
+This would add a map with `{key=currentRequest, value=myRequest}` to each trace event generated in that same thread.
+This is particularly useful if you wish to add threadlocal context information to multiple events.
+
+Note that only `GenericTraceEventConsumer`s are able to retrieve the context map passed by the tracer (as it is part of
+the `TraceEvent` data object. Specific `TraceEventConsumer`s (that implement the original tracer interface), cannot
+access the context while processing events.
 
 ### Advanced examples
 
 Advanced examples of using this trace event mechanism are:
 
-* Sending events to a simulation system, which simulates the environment of the system. For example,
-  an event that the cabin temperature has been set, may be processed by a simulator which uses a
-  trace event consumer to receive such messages.
+* Sending events to a simulation system, which simulates the environment of the system. For example, an event that the
+  cabin temperature has been set, may be processed by a simulator which uses a trace event consumer to receive such
+  messages.
 
 * Displaying events on a dashboard, to gain more insight in the current status of the system, rather
   than having only a scrolling log to look at.
@@ -533,13 +552,18 @@ Contributors: Timon Kanters, Jeroen Erik Jensen, Krzysztof Karczewski
 
 ## Release notes
 
+### 1.5.0
+
+* Added ability to store threadlocal diagnostic context to trace events. This context can be processed
+  by `GenericTraceEventConsumer`s.
+
 ### 1.4.1
 
 * Updated POM dependencies.
 
 * Replaced deprecated `Channel` methods `offer` and `poll` with current method variants `trySend` and `tryReceive`.
 
-* Replaced some `internal` properties with `private` to be stricter on visibility. 
+* Replaced some `internal` properties with `private` to be stricter on visibility.
 
 * Removed redundant `suspend` modifiers from methods.
 

--- a/memoization/pom.xml
+++ b/memoization/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.kotlin</groupId>
         <artifactId>kotlin-tools</artifactId>
-        <version>1.4.1</version>
+        <version>1.5.0</version>
     </parent>
 
     <artifactId>memoization</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>com.tomtom.kotlin</groupId>
     <artifactId>kotlin-tools</artifactId>
-    <version>1.4.1</version>
+    <version>1.5.0</version>
     <packaging>pom</packaging>
 
     <name>Kotlin Tools</name>

--- a/traceevents/pom.xml
+++ b/traceevents/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.kotlin</groupId>
         <artifactId>kotlin-tools</artifactId>
-        <version>1.4.1</version>
+        <version>1.5.0</version>
     </parent>
 
     <artifactId>traceevents</artifactId>

--- a/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceDiagnosticContext.kt
+++ b/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceDiagnosticContext.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2012-2021, TomTom (http://tomtom.com).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tomtom.kotlin.traceevents
+
+/**
+ * This class allows storing ThreadLocal trace context.
+ *
+ * Inspired by basic MDC implementation from org.org.slf4j.helpers.BasicMDCAdapter.
+ * This implementation allows storing any object type, not just strings, in a map.
+ */
+object TraceDiagnosticContext {
+
+    private val inheritableThreadLocal = object : InheritableThreadLocal<MutableMap<String, Any>?>() {
+        fun childValue(parentValue: Map<String, Any>?) = parentValue?.let { HashMap(it) }
+    }
+
+    val keys: Set<Any>?
+        get() = inheritableThreadLocal.get()?.keys
+
+    fun put(key: String, value: Any) =
+        inheritableThreadLocal.get()?.let { it[key] = value }
+            ?: inheritableThreadLocal.set(HashMap(mapOf(key to value)))
+
+    fun get(key: String) = inheritableThreadLocal.get()?.get(key)
+
+    fun remove(key: String) = inheritableThreadLocal.get()?.remove(key)
+
+    fun clear() {
+        inheritableThreadLocal.get()?.clear()
+        inheritableThreadLocal.remove()
+    }
+
+    fun getCopyOfContextMap(): Map<String, Any>? = inheritableThreadLocal.get()?.let { HashMap(it) }
+
+    fun setContextMap(contextMap: Map<String, Any>) = inheritableThreadLocal.set(HashMap(contextMap))
+}

--- a/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceEvent.kt
+++ b/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceEvent.kt
@@ -26,6 +26,7 @@ import java.time.LocalDateTime
  * @param tracerClassName Class logging the event.
  * @param taggingClassName Tagging class passed to event, for convenience of debugging.
  * @param context Disambiguation context for event tracers with the same tags.
+ * @param traceDiagnosticContext Optional, additional threadlocal context for trace events.
  * @param interfaceName Interface name, derived from [TraceEventListener].
  * @param stackTraceHolder Throwable from which a stack trace can be produced. `null` when unavailable.
  * @param eventName Function name in interface, which represents the trace event name.
@@ -37,10 +38,11 @@ data class TraceEvent(
     val tracerClassName: String,
     val taggingClassName: String,
     val context: String,
+    val traceDiagnosticContext: Map<String, Any?>? = emptyMap(),
     val interfaceName: String,
     val stackTraceHolder: Throwable?,
     val eventName: String,
-    val args: Array<Any?>,
+    val args: Array<Any?>
 ) {
     /**
      * Need to override the `equals` and `hashCode` functions, as the class contains
@@ -57,6 +59,7 @@ data class TraceEvent(
         if (tracerClassName != other.tracerClassName) return false
         if (taggingClassName != other.taggingClassName) return false
         if (context != other.context) return false
+        if (traceDiagnosticContext != other.traceDiagnosticContext) return false
         if (interfaceName != other.interfaceName) return false
         if (stackTraceHolder != other.stackTraceHolder) return false
         if (eventName != other.eventName) return false
@@ -71,6 +74,7 @@ data class TraceEvent(
         result = 31 * result + tracerClassName.hashCode()
         result = 31 * result + taggingClassName.hashCode()
         result = 31 * result + context.hashCode()
+        result = 31 * result + traceDiagnosticContext.hashCode()
         result = 31 * result + interfaceName.hashCode()
         result = 31 * result + (stackTraceHolder?.hashCode() ?: 0)
         result = 31 * result + eventName.hashCode()

--- a/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceEvent.kt
+++ b/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceEvent.kt
@@ -38,7 +38,7 @@ data class TraceEvent(
     val tracerClassName: String,
     val taggingClassName: String,
     val context: String,
-    val traceThreadLocalContext: Map<String, Any?>? = emptyMap(),
+    val traceThreadLocalContext: Map<String, Any?>?,
     val interfaceName: String,
     val stackTraceHolder: Throwable?,
     val eventName: String,

--- a/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceEvent.kt
+++ b/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceEvent.kt
@@ -26,7 +26,7 @@ import java.time.LocalDateTime
  * @param tracerClassName Class logging the event.
  * @param taggingClassName Tagging class passed to event, for convenience of debugging.
  * @param context Disambiguation context for event tracers with the same tags.
- * @param traceDiagnosticContext Optional, additional threadlocal context for trace events.
+ * @param traceThreadLocalContext Optional, additional thread-local context for trace events.
  * @param interfaceName Interface name, derived from [TraceEventListener].
  * @param stackTraceHolder Throwable from which a stack trace can be produced. `null` when unavailable.
  * @param eventName Function name in interface, which represents the trace event name.
@@ -38,7 +38,7 @@ data class TraceEvent(
     val tracerClassName: String,
     val taggingClassName: String,
     val context: String,
-    val traceDiagnosticContext: Map<String, Any?>? = emptyMap(),
+    val traceThreadLocalContext: Map<String, Any?>? = emptyMap(),
     val interfaceName: String,
     val stackTraceHolder: Throwable?,
     val eventName: String,
@@ -59,7 +59,7 @@ data class TraceEvent(
         if (tracerClassName != other.tracerClassName) return false
         if (taggingClassName != other.taggingClassName) return false
         if (context != other.context) return false
-        if (traceDiagnosticContext != other.traceDiagnosticContext) return false
+        if (traceThreadLocalContext != other.traceThreadLocalContext) return false
         if (interfaceName != other.interfaceName) return false
         if (stackTraceHolder != other.stackTraceHolder) return false
         if (eventName != other.eventName) return false
@@ -74,7 +74,7 @@ data class TraceEvent(
         result = 31 * result + tracerClassName.hashCode()
         result = 31 * result + taggingClassName.hashCode()
         result = 31 * result + context.hashCode()
-        result = 31 * result + traceDiagnosticContext.hashCode()
+        result = 31 * result + traceThreadLocalContext.hashCode()
         result = 31 * result + interfaceName.hashCode()
         result = 31 * result + (stackTraceHolder?.hashCode() ?: 0)
         result = 31 * result + eventName.hashCode()

--- a/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceThreadLocalContext.kt
+++ b/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceThreadLocalContext.kt
@@ -16,12 +16,12 @@
 package com.tomtom.kotlin.traceevents
 
 /**
- * This class allows storing ThreadLocal trace context.
+ * This class allows storing thread-local trace context.
  *
  * Inspired by basic MDC implementation from org.org.slf4j.helpers.BasicMDCAdapter.
  * This implementation allows storing any object type, not just strings, in a map.
  */
-object TraceDiagnosticContext {
+object TraceThreadLocalContext {
 
     private val inheritableThreadLocal = object : InheritableThreadLocal<MutableMap<String, Any>?>() {
         fun childValue(parentValue: Map<String, Any>?) = parentValue?.let { HashMap(it) }

--- a/traceevents/src/main/java/com/tomtom/kotlin/traceevents/Tracer.kt
+++ b/traceevents/src/main/java/com/tomtom/kotlin/traceevents/Tracer.kt
@@ -302,7 +302,7 @@ class Tracer private constructor(
             tracerClassName = tracerClassName,
             taggingClassName = taggingClassName,
             context = context,
-            traceDiagnosticContext = TraceDiagnosticContext.getCopyOfContextMap(),
+            traceThreadLocalContext = TraceThreadLocalContext.getCopyOfContextMap(),
             interfaceName = method.declaringClass.name,
             stackTraceHolder = Throwable(),
             eventName = method.name,
@@ -778,9 +778,9 @@ class Tracer private constructor(
                 sb.append(", context=${traceEvent.context}")
             }
 
-            // Diagnostics
-            if (traceEvent.traceDiagnosticContext != null) {
-                sb.append(", traceDiagnosticContext=${traceEvent.traceDiagnosticContext}")
+            // Thread-local context
+            if (traceEvent.traceThreadLocalContext != null) {
+                sb.append(", traceThreadLocalContext=${traceEvent.traceThreadLocalContext}")
             }
 
             // Stack trace for last parameter, if it's an exception.

--- a/traceevents/src/main/java/com/tomtom/kotlin/traceevents/Tracer.kt
+++ b/traceevents/src/main/java/com/tomtom/kotlin/traceevents/Tracer.kt
@@ -302,10 +302,11 @@ class Tracer private constructor(
             tracerClassName = tracerClassName,
             taggingClassName = taggingClassName,
             context = context,
+            traceDiagnosticContext = TraceDiagnosticContext.getCopyOfContextMap(),
             interfaceName = method.declaringClass.name,
             stackTraceHolder = Throwable(),
             eventName = method.name,
-            args = args ?: arrayOf<Any?>()
+            args = args ?: arrayOf()
         )
 
         /**
@@ -777,8 +778,13 @@ class Tracer private constructor(
                 sb.append(", context=${traceEvent.context}")
             }
 
+            // Diagnostics
+            if (traceEvent.traceDiagnosticContext != null) {
+                sb.append(", traceDiagnosticContext=${traceEvent.traceDiagnosticContext}")
+            }
+
             // Stack trace for last parameter, if it's an exception.
-            if (includeExceptionStackTrace && !traceEvent.args.isEmpty()) {
+            if (includeExceptionStackTrace && traceEvent.args.isNotEmpty()) {
                 (traceEvent.args.last() as? Throwable)?.let {
                     sb.append("\n")
                     sb.append(formatThrowable(it, includeExceptionStackTrace))

--- a/traceevents/src/test/java/com/tomtom/kotlin/traceevents/TestUtils.kt
+++ b/traceevents/src/test/java/com/tomtom/kotlin/traceevents/TestUtils.kt
@@ -29,7 +29,7 @@ import kotlin.reflect.jvm.jvmName
  */
 fun MockKMatcherScope.traceEq(
     context: String,
-    traceDiagnosticContext: Map<String, Any?>? = null,
+    traceThreadLocalContext: Map<String, Any?>? = null,
     logLevel: LogLevel,
     functionName: String,
     vararg args: Any
@@ -39,7 +39,7 @@ fun MockKMatcherScope.traceEq(
         traceEvent.logLevel == logLevel &&
                 traceEvent.taggingClassName == TracerTest::class.jvmName &&
                 traceEvent.context == context &&
-                traceEvent.traceDiagnosticContext == traceDiagnosticContext &&
+                traceEvent.traceThreadLocalContext == traceThreadLocalContext &&
                 traceEvent.interfaceName == TracerTest.MyEvents::class.jvmName &&
                 traceEvent.eventName == functionName &&
                 traceEvent.args.map { it?.javaClass } == args.map { it.javaClass } &&
@@ -91,10 +91,10 @@ fun setUpTracerTest() {
     /**
      * For every test case remove all consumer, cancel the processor (which will be restarted
      * at next add consumer) and flush all events. Make sure that when the processor starts,
-     * it starts on the thread of this test and clears all threadlocal data.
+     * it starts on the thread of this test and clears all thread-local data.
      */
     runBlocking {
-        TraceDiagnosticContext.clear()
+        TraceThreadLocalContext.clear()
         TraceLog.setLogger()
         Tracer.eventProcessorScope = CoroutineScope(Dispatchers.Unconfined)
         Tracer.setTraceEventLoggingMode(Tracer.Companion.LoggingMode.SYNC)

--- a/traceevents/src/test/java/com/tomtom/kotlin/traceevents/TestUtils.kt
+++ b/traceevents/src/test/java/com/tomtom/kotlin/traceevents/TestUtils.kt
@@ -91,7 +91,7 @@ fun setUpTracerTest() {
     /**
      * For every test case remove all consumer, cancel the processor (which will be restarted
      * at next add consumer) and flush all events. Make sure that when the processor starts,
-     * it starts on the thread of this test and clear all threadlocal data.
+     * it starts on the thread of this test and clears all threadlocal data.
      */
     runBlocking {
         TraceDiagnosticContext.clear()

--- a/traceevents/src/test/java/com/tomtom/kotlin/traceevents/TracerTest.kt
+++ b/traceevents/src/test/java/com/tomtom/kotlin/traceevents/TracerTest.kt
@@ -93,11 +93,15 @@ class TracerTest {
         sut.eventNoArgs()
         sut.eventString("abc")
         sut.eventIntsString(10, 20, "abc")
+        sut.eventIntsString(number1 = 10, number2 = 20, message = "abc")
+        sut.eventIntsString(message = "abc", number1 = 10, number2 = 20)
 
         // THEN
         coVerifySequence {
             consumer.eventNoArgs()
             consumer.eventString(eq("abc"))
+            consumer.eventIntsString(eq(10), eq(20), eq("abc"))
+            consumer.eventIntsString(eq(10), eq(20), eq("abc"))
             consumer.eventIntsString(eq(10), eq(20), eq("abc"))
         }
     }
@@ -167,11 +171,15 @@ class TracerTest {
         sut.eventNoArgs()
         sut.eventString("xyz")
         sut.eventIntsString(10, 20, "abc")
+        sut.eventIntsString(number1 = 10, number2 = 20, message = "abc")
+        sut.eventIntsString(message = "abc", number1 = 10, number2 = 20)
 
         // THEN
         coVerifySequence {
             consumer.consumeTraceEvent(traceEq("", null, LogLevel.DEBUG, "eventNoArgs"))
             consumer.consumeTraceEvent(traceEq("", null, LogLevel.DEBUG, "eventString", "xyz"))
+            consumer.consumeTraceEvent(traceEq("", null, LogLevel.ERROR, "eventIntsString", 10, 20, "abc"))
+            consumer.consumeTraceEvent(traceEq("", null, LogLevel.ERROR, "eventIntsString", 10, 20, "abc"))
             consumer.consumeTraceEvent(traceEq("", null, LogLevel.ERROR, "eventIntsString", 10, 20, "abc"))
         }
     }

--- a/traceevents/src/test/java/com/tomtom/kotlin/traceevents/TracerTest.kt
+++ b/traceevents/src/test/java/com/tomtom/kotlin/traceevents/TracerTest.kt
@@ -211,14 +211,14 @@ class TracerTest {
     }
 
     @Test
-    fun `generic consumer with diagnostic context`() {
+    fun `generic consumer with thread-local context`() {
         // GIVEN
         val consumer = spyk(GenericConsumer())
         Tracer.addTraceEventConsumer(consumer)
 
         // WHEN
         sut.eventNoArgs()
-        TraceDiagnosticContext.put("id", 123)
+        TraceThreadLocalContext.put("id", 123)
         sut.eventNoArgs()
 
 

--- a/uid/pom.xml
+++ b/uid/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.kotlin</groupId>
         <artifactId>kotlin-tools</artifactId>
-        <version>1.4.1</version>
+        <version>1.5.0</version>
     </parent>
 
     <artifactId>uid</artifactId>


### PR DESCRIPTION
* Added ability to store threadlocal diagnostic context to trace events. This context can be processed
  by `GenericTraceEventConsumer`s. Initial idea by Chris Owen.