### PR TITLE
Added getParametersMap to TraceEvent

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,11 @@ There are 2 types of trace events consumers:
    `TraceEventListener` interface.
 
    These consumers receive every event thrown in the system. They receive the event information as
-   part of their `GenericTraceEventConsumer.consumeTraceEvent` implementation.
+   part of their `GenericTraceEventConsumer.consumeTraceEvent` implementation. This method gets
+   a `TraceEvent` parameter that contains all information about the trace event, including date/time
+   of occurence, class name, context information (per tracer instance, or even per thread the trace
+   was created on), and the values of the parameters of the trace event method call (which can be
+   obtained positionally, or by name, as a convenience).
 
    Generic consumers typically forward events to another system, such as the Android `Log`, store
    them in a database, or perhaps even send them across application (or machine) boundaries.

--- a/README.md
+++ b/README.md
@@ -636,7 +636,7 @@ Contributors: Timon Kanters, Jeroen Erik Jensen, Krzysztof Karczewski
 
 * Added `getParametersMap` to `TraceEvent`, which allows generic trace event consumers to access parameters and 
 their values through a map that maps parameters names to their values. The other way to access parameter values
-is by using `args`, which is an array with paramters values, in the order of the method declaration.  
+is by using `args`, which is an array with parameter values, in the order of the method declaration.  
 
 ### 1.5.0
 

--- a/README.md
+++ b/README.md
@@ -628,6 +628,12 @@ Contributors: Timon Kanters, Jeroen Erik Jensen, Krzysztof Karczewski
 
 ## Release notes
 
+### 1.5.1
+
+* Added `getParametersMap` to `TraceEvent`, which allows generic trace event consumers to access parameters and 
+their values through a map that maps parameters names to their values. The other way to access parameter values
+is by using `args`, which is an array with paramters values, in the order of the method declaration.  
+
 ### 1.5.0
 
 * Added ability to store thread-local (MDC-style) context to trace events using `TraceThreadLocalContext`. 

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ There are 2 types of trace events consumers:
    a `TraceEvent` parameter that contains all information about the trace event, including date/time
    of occurence, class name, context information (per tracer instance, or even per thread the trace
    was created on), and the values of the parameters of the trace event method call (which can be
-   obtained positionally, or by name, as a convenience).
+   obtained positionally, or by name from `getNamedParametersMap`, as a convenience).
 
    Generic consumers typically forward events to another system, such as the Android `Log`, store
    them in a database, or perhaps even send them across application (or machine) boundaries.
@@ -634,7 +634,7 @@ Contributors: Timon Kanters, Jeroen Erik Jensen, Krzysztof Karczewski
 
 ### 1.5.1
 
-* Added `getParametersMap` to `TraceEvent`, which allows generic trace event consumers to access parameters and 
+* Added `getNamedParametersMap` to `TraceEvent`, which allows generic trace event consumers to access parameters and 
 their values through a map that maps parameters names to their values. The other way to access parameter values
 is by using `args`, which is an array with parameter values, in the order of the method declaration.  
 

--- a/memoization/pom.xml
+++ b/memoization/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.kotlin</groupId>
         <artifactId>kotlin-tools</artifactId>
-        <version>1.5.0</version>
+        <version>1.5.1</version>
     </parent>
 
     <artifactId>memoization</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>com.tomtom.kotlin</groupId>
     <artifactId>kotlin-tools</artifactId>
-    <version>1.5.0</version>
+    <version>1.5.1</version>
     <packaging>pom</packaging>
 
     <name>Kotlin Tools</name>

--- a/traceevents/pom.xml
+++ b/traceevents/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.kotlin</groupId>
         <artifactId>kotlin-tools</artifactId>
-        <version>1.5.0</version>
+        <version>1.5.1</version>
     </parent>
 
     <artifactId>traceevents</artifactId>

--- a/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceEvent.kt
+++ b/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceEvent.kt
@@ -32,7 +32,7 @@ import java.time.LocalDateTime
  * @param eventName Function name in interface, which represents the trace event name.
  * @param args Trace event arguments. Specified as array, to avoid expensive array/list conversions.
  * @param parameterNames Names of the parameters, in the same order as the `args` values. Normally, you would use
- * `getParametersMap` to access the parameters names and values. If `null` the map could not be created for some reason.
+ * `getNamedParametersMap` to access the parameters names and values. If `null` the map could not be created for some reason.
  * You can still use the `args` array in that case.
  */
 data class TraceEvent(
@@ -57,7 +57,7 @@ data class TraceEvent(
      * Returns an empty map for parameterless methods and `null` if 1 or more parameter names are not
      * available for some reason.
      */
-    fun getParametersMap() = if (parameterNames == null) null else
+    fun getNamedParametersMap() = if (parameterNames == null) null else
         parameterNames.indices.associateBy({ parameterNames[it] }, { args[it] })
 
     /**

--- a/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceEvent.kt
+++ b/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceEvent.kt
@@ -42,7 +42,8 @@ data class TraceEvent(
     val interfaceName: String,
     val stackTraceHolder: Throwable?,
     val eventName: String,
-    val args: Array<Any?>
+    val args: Array<Any?>,
+    val parameterNames: Array<String>
 ) {
     /**
      * Need to override the `equals` and `hashCode` functions, as the class contains
@@ -64,6 +65,7 @@ data class TraceEvent(
         if (stackTraceHolder != other.stackTraceHolder) return false
         if (eventName != other.eventName) return false
         if (!args.contentDeepEquals(other.args)) return false
+        if (!parameterNames.contentEquals(other.parameterNames)) return false
 
         return true
     }
@@ -79,6 +81,7 @@ data class TraceEvent(
         result = 31 * result + (stackTraceHolder?.hashCode() ?: 0)
         result = 31 * result + eventName.hashCode()
         result = 31 * result + args.contentDeepHashCode()
+        result = 31 * result + parameterNames.contentHashCode()
         return result
     }
 }

--- a/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceEvent.kt
+++ b/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceEvent.kt
@@ -53,12 +53,12 @@ data class TraceEvent(
     }
 
     /**
-     * Get the method parameters as a map that maps the parameter name to its value.
-     * Returns an empty map for parameterless methods and `null` if 1 or more parameter names are not
-     * available for some reason.
+     * Gets the method parameters as a map that maps the parameter name to its value.
+     * Returns an empty map for parameterless methods and `null` if 1 or more parameter names are
+     * not available for some reason.
      */
-    fun getNamedParametersMap() = if (parameterNames == null) null else
-        parameterNames.indices.associateBy({ parameterNames[it] }, { args[it] })
+    fun getNamedParametersMap() =
+        parameterNames?.indices?.associateBy({ parameterNames[it] }, { args[it] })
 
     /**
      * Need to override the `equals` and `hashCode` functions, as the class contains

--- a/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceEvent.kt
+++ b/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceEvent.kt
@@ -48,16 +48,17 @@ data class TraceEvent(
     val args: Array<Any?>,
     val parameterNames: Array<String>?
 ) {
+    init {
+        check(parameterNames == null || args.size == parameterNames.size)
+    }
+
     /**
      * Get the method parameters as a map that maps the parameter name to its value.
      * Returns an empty map for parameterless methods and `null` if 1 or more parameter names are not
      * available for some reason.
      */
-    fun getParametersMap(): Map<String, Any?>? = if (parameterNames == null) null else {
-        var map = mutableMapOf<String, Any?>()
-        parameterNames.indices.forEach { map[parameterNames[it]] = args[it] }
-        map
-    }
+    fun getParametersMap() = if (parameterNames == null) null else
+        parameterNames.indices.associateBy({ parameterNames[it] }, { args[it] })
 
     /**
      * Need to override the `equals` and `hashCode` functions, as the class contains

--- a/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceEvent.kt
+++ b/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceEvent.kt
@@ -54,7 +54,7 @@ data class TraceEvent(
      * available for some reason.
      */
     fun getParametersMap(): Map<String, Any?>? = if (parameterNames == null) null else {
-        var map: MutableMap<String, Any?> = mutableMapOf()
+        var map = mutableMapOf<String, Any?>()
         parameterNames.indices.forEach { map[parameterNames[it]] = args[it] }
         map
     }

--- a/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceEvent.kt
+++ b/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceEvent.kt
@@ -31,6 +31,8 @@ import java.time.LocalDateTime
  * @param stackTraceHolder Throwable from which a stack trace can be produced. `null` when unavailable.
  * @param eventName Function name in interface, which represents the trace event name.
  * @param args Trace event arguments. Specified as array, to avoid expensive array/list conversions.
+ * @param parameterNames Names of the parameters, in the same order as the `args` values. Normally, you would use
+ * `getParametersMap` to access the parameters names and values.
  */
 data class TraceEvent(
     val dateTime: LocalDateTime,
@@ -45,6 +47,16 @@ data class TraceEvent(
     val args: Array<Any?>,
     val parameterNames: Array<String>
 ) {
+    /**
+     * Get the method parameters as a map that maps the parameter name to its value.
+     */
+    fun getParametersMap(): Map<String, Any?> {
+        assert(args.size == parameterNames.size)
+        var map: MutableMap<String, Any?> = mutableMapOf()
+        args.indices.forEach { map.put(parameterNames[it], args[it]) }
+        return map
+    }
+
     /**
      * Need to override the `equals` and `hashCode` functions, as the class contains
      * an `Array`. Otherwise, `equals` would always return `false`.

--- a/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceEvent.kt
+++ b/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceEvent.kt
@@ -32,7 +32,8 @@ import java.time.LocalDateTime
  * @param eventName Function name in interface, which represents the trace event name.
  * @param args Trace event arguments. Specified as array, to avoid expensive array/list conversions.
  * @param parameterNames Names of the parameters, in the same order as the `args` values. Normally, you would use
- * `getParametersMap` to access the parameters names and values.
+ * `getParametersMap` to access the parameters names and values. If `null` the map could not be created for some reason.
+ * You can still use the `args` array in that case.
  */
 data class TraceEvent(
     val dateTime: LocalDateTime,
@@ -45,16 +46,17 @@ data class TraceEvent(
     val stackTraceHolder: Throwable?,
     val eventName: String,
     val args: Array<Any?>,
-    val parameterNames: Array<String>
+    val parameterNames: Array<String>?
 ) {
     /**
      * Get the method parameters as a map that maps the parameter name to its value.
+     * Returns an empty map for parameterless methods and `null` if 1 or more parameter names are not
+     * available for some reason.
      */
-    fun getParametersMap(): Map<String, Any?> {
-        assert(args.size == parameterNames.size)
+    fun getParametersMap(): Map<String, Any?>? = if (parameterNames == null) null else {
         var map: MutableMap<String, Any?> = mutableMapOf()
-        args.indices.forEach { map.put(parameterNames[it], args[it]) }
-        return map
+        parameterNames.indices.forEach { map[parameterNames[it]] = args[it] }
+        map
     }
 
     /**
@@ -78,7 +80,6 @@ data class TraceEvent(
         if (eventName != other.eventName) return false
         if (!args.contentDeepEquals(other.args)) return false
         if (!parameterNames.contentEquals(other.parameterNames)) return false
-
         return true
     }
 

--- a/traceevents/src/main/java/com/tomtom/kotlin/traceevents/Tracer.kt
+++ b/traceevents/src/main/java/com/tomtom/kotlin/traceevents/Tracer.kt
@@ -294,6 +294,11 @@ class Tracer private constructor(
             return null
         }
 
+        /**
+         * Get the parameter names for the method.
+         */
+        val parameterNames = method.parameters.map{ it.name }
+
         // Send the event to the event processor consumer, non-blocking.
         val now = LocalDateTime.now()
         val event = TraceEvent(
@@ -306,7 +311,8 @@ class Tracer private constructor(
             interfaceName = method.declaringClass.name,
             stackTraceHolder = Throwable(),
             eventName = method.name,
-            args = args ?: arrayOf()
+            args = args ?: arrayOf(),
+            parameterNames = parameterNames.toTypedArray()
         )
 
         /**

--- a/traceevents/src/main/java/com/tomtom/kotlin/traceevents/Tracer.kt
+++ b/traceevents/src/main/java/com/tomtom/kotlin/traceevents/Tracer.kt
@@ -299,7 +299,8 @@ class Tracer private constructor(
 
         /**
          * Get the parameter names for the method.
-         * For performance reasons, Make sure this code is executed only once per method call.
+         * For performance reasons, make sure this code is normally executed only once per method call. Note that
+         * this method may be called by multiple threads, so it must be thread-safe as well.
          * Also make sure the parameter names are only provided if there is exactly 1 name for each parameter only.
          */
         val parameterNames: Array<String>?

--- a/traceevents/src/main/java/com/tomtom/kotlin/traceevents/Tracer.kt
+++ b/traceevents/src/main/java/com/tomtom/kotlin/traceevents/Tracer.kt
@@ -307,13 +307,11 @@ class Tracer private constructor(
         if (parameterNamesCache.containsKey(method)) {
             parameterNames = parameterNamesCache.get(method)
         } else {
-            val kotlinFunction = method.kotlinFunction
-            parameterNames = if (kotlinFunction == null || args == null) null else {
-                val nonEmptyParametersNames = kotlinFunction.parameters
-                    .filter { it.name != null }.map { it.name!! }.toTypedArray()
-                if (args.size != nonEmptyParametersNames.size) null else {
-                    parameterNamesCache[method] = nonEmptyParametersNames
-                    nonEmptyParametersNames
+            parameterNames = if (args == null) null else {
+                val nonEmptyParameterNames = method.kotlinFunction?.parameters?.mapNotNull { it.name }?.toTypedArray()
+                if (args.size != nonEmptyParameterNames?.size) null else {
+                    parameterNamesCache[method] = nonEmptyParameterNames
+                    nonEmptyParameterNames
                 }
             }
         }

--- a/traceevents/src/main/java/com/tomtom/kotlin/traceevents/Tracer.kt
+++ b/traceevents/src/main/java/com/tomtom/kotlin/traceevents/Tracer.kt
@@ -306,13 +306,12 @@ class Tracer private constructor(
          * this method may be called by multiple threads, so it must be thread-safe as well.
          * Also make sure the parameter names are only provided if there is exactly 1 name for each parameter only.
          */
-        val parameterNames: Array<String>? =
-            parameterNamesCache.getOrPut(method) {
-                method.kotlinFunction?.parameters
-                    ?.mapNotNull { it.name }
-                    ?.takeIf { it.size == args?.size }
-                    ?.toTypedArray()
-            }
+        val parameterNames = parameterNamesCache[method] ?: method.kotlinFunction
+            ?.parameters
+            ?.mapNotNull { it.name }
+            ?.takeIf { it.size == args?.size }
+            ?.toTypedArray()
+            ?.also { parameterNamesCache[method] = it }
 
         // Send the event to the event processor consumer, non-blocking.
         val now = LocalDateTime.now()

--- a/traceevents/src/test/java/com/tomtom/kotlin/traceevents/NamedParametersTest.kt
+++ b/traceevents/src/test/java/com/tomtom/kotlin/traceevents/NamedParametersTest.kt
@@ -40,31 +40,7 @@ class NamedParametersTest {
 
     class GenericConsumer : GenericTraceEventConsumer, TraceEventConsumer {
         override suspend fun consumeTraceEvent(traceEvent: TraceEvent) =
-            TraceLog.log(LogLevel.DEBUG, "TAG", "${traceEvent.getNamedParametersMap()}")
-    }
-
-    companion object {
-        val TAG = TracerTest::class.simpleName
-        val sut = Tracer.Factory.create<MyEvents>(this)
-
-        fun MockKMatcherScope.traceEq(
-            context: String,
-            traceThreadLocalContext: Map<String, Any?>? = null,
-            logLevel: LogLevel,
-            functionName: String,
-            vararg args: Any
-        ) =
-            match<TraceEvent> { traceEvent ->
-                val eq = traceEvent.logLevel == logLevel &&
-                        traceEvent.taggingClassName == NamedParametersTest::class.jvmName &&
-                        traceEvent.context == context &&
-                        traceEvent.traceThreadLocalContext == traceThreadLocalContext &&
-                        traceEvent.interfaceName == MyEvents::class.jvmName &&
-                        traceEvent.eventName == functionName &&
-                        traceEvent.args.map { it?.javaClass } == args.map { it.javaClass } &&
-                        traceEvent.args.contentDeepEquals(args)
-                eq
-            }
+            TraceLog.log(LogLevel.DEBUG, "TAG", "${traceEvent.getNamedParametersMap()}}")
     }
 
     @Before
@@ -137,5 +113,29 @@ class NamedParametersTest {
                     "$TIME DEBUG NamedParametersTest: event=event(final, 789, [])\n" +
                     "$TIME DEBUG TAG: {message=final, someInt=789, anyList=[]}\n"
         assertEquals(expected, actual)
+    }
+
+    companion object {
+        val TAG = TracerTest::class.simpleName
+        val sut = Tracer.Factory.create<MyEvents>(this)
+
+        fun MockKMatcherScope.traceEq(
+            context: String,
+            traceThreadLocalContext: Map<String, Any?>? = null,
+            logLevel: LogLevel,
+            functionName: String,
+            vararg args: Any
+        ) =
+            match<TraceEvent> { traceEvent ->
+                val eq = traceEvent.logLevel == logLevel &&
+                    traceEvent.taggingClassName == NamedParametersTest::class.jvmName &&
+                    traceEvent.context == context &&
+                    traceEvent.traceThreadLocalContext == traceThreadLocalContext &&
+                    traceEvent.interfaceName == MyEvents::class.jvmName &&
+                    traceEvent.eventName == functionName &&
+                    traceEvent.args.map { it?.javaClass } == args.map { it.javaClass } &&
+                    traceEvent.args.contentDeepEquals(args)
+                eq
+            }
     }
 }

--- a/traceevents/src/test/java/com/tomtom/kotlin/traceevents/NamedParametersTest.kt
+++ b/traceevents/src/test/java/com/tomtom/kotlin/traceevents/NamedParametersTest.kt
@@ -40,7 +40,7 @@ class NamedParametersTest {
 
     class GenericConsumer : GenericTraceEventConsumer, TraceEventConsumer {
         override suspend fun consumeTraceEvent(traceEvent: TraceEvent) =
-            TraceLog.log(LogLevel.DEBUG, "TAG", "${traceEvent.getNamedParametersMap()}}")
+            TraceLog.log(LogLevel.DEBUG, "TAG", "${traceEvent.getNamedParametersMap()}")
     }
 
     @Before

--- a/traceevents/src/test/java/com/tomtom/kotlin/traceevents/NamedParametersTest.kt
+++ b/traceevents/src/test/java/com/tomtom/kotlin/traceevents/NamedParametersTest.kt
@@ -40,7 +40,7 @@ class NamedParametersTest {
 
     class GenericConsumer : GenericTraceEventConsumer, TraceEventConsumer {
         override suspend fun consumeTraceEvent(traceEvent: TraceEvent) =
-            TraceLog.log(LogLevel.DEBUG, "TAG", "${traceEvent.getParametersMap()}")
+            TraceLog.log(LogLevel.DEBUG, "TAG", "${traceEvent.getNamedParametersMap()}")
     }
 
     companion object {

--- a/traceevents/src/test/java/com/tomtom/kotlin/traceevents/NamedParametersTest.kt
+++ b/traceevents/src/test/java/com/tomtom/kotlin/traceevents/NamedParametersTest.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2012-2021, TomTom (http://tomtom.com).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tomtom.kotlin.traceevents
+
+import com.tomtom.kotlin.traceevents.TraceLog.LogLevel
+import io.mockk.coVerify
+import io.mockk.coVerifySequence
+import io.mockk.spyk
+import io.mockk.verify
+import io.mockk.verifySequence
+import kotlinx.coroutines.runBlocking
+import nl.jqno.equalsverifier.EqualsVerifier
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class NamedParametersTest {
+
+    interface MyEvents : TraceEventListener {
+        fun eventNoArgs()
+        fun eventWithParameters(message: String, someInt: Int, anyList: List<Int>)
+    }
+
+    class SpecificConsumer : MyEvents, TraceEventConsumer {
+        override fun eventNoArgs() {}
+        override fun eventWithParameters(message: String, someInt: Int, anyList: List<Int>) {
+
+        }
+    }
+
+    class GenericConsumer : GenericTraceEventConsumer, TraceEventConsumer {
+        override suspend fun consumeTraceEvent(traceEvent: TraceEvent) =
+            TraceLog.log(LogLevel.DEBUG, "TAG", "${traceEvent}")
+    }
+
+    companion object {
+        val TAG = TracerTest::class.simpleName
+        val sut = Tracer.Factory.create<MyEvents>(this)
+    }
+
+    @Before
+    fun setUp() {
+        setUpTracerTest()
+    }
+
+    @Test
+    fun `use named parameters in a pecific consumer`() {
+        // GIVEN
+        val consumer = spyk(SpecificConsumer())
+        Tracer.addTraceEventConsumer(consumer)
+
+        // WHEN
+        sut.eventNoArgs()
+        sut.eventWithParameters(message = "my string", someInt = 123, anyList = listOf(1, 2, 3))
+        sut.eventWithParameters("my string", 123, listOf(1, 2, 3))
+
+        // THEN
+        coVerifySequence {
+            consumer.eventNoArgs()
+            consumer.eventWithParameters(eq("my string"), eq(123), eq(listOf(1, 2, 3)))
+        }
+    }
+
+    @Test
+    fun `use named parameters generic consumer with no context`() {
+        // GIVEN
+        val consumer = spyk(GenericConsumer())
+        Tracer.addTraceEventConsumer(consumer)
+
+        // WHEN
+        sut.eventNoArgs()
+        sut.eventWithParameters("my string", 123, listOf(1, 2, 3))
+
+        // THEN
+        coVerifySequence {
+            consumer.consumeTraceEvent(traceEq("", null, LogLevel.DEBUG, "eventNoArgs"))
+            consumer.consumeTraceEvent(traceEq("", null, LogLevel.ERROR,
+                "eventWithParameters", "my string", 123, listOf(1, 2, 3)))
+        }
+    }
+}

--- a/traceevents/src/test/java/com/tomtom/kotlin/traceevents/NamedParametersTest.kt
+++ b/traceevents/src/test/java/com/tomtom/kotlin/traceevents/NamedParametersTest.kt
@@ -63,9 +63,9 @@ class NamedParametersTest {
         // THEN
         coVerifySequence {
             consumer.event()
-            consumer.event(eq("my string"), eq(123), eq(listOf(1, 2, 3)))
-            consumer.event(eq("more"), eq(456), eq(listOf(5)))
-            consumer.event(eq("final"), eq(789), eq(listOf()))
+            consumer.event("my string", 123, listOf(1, 2, 3))
+            consumer.event("more", 456, listOf(5))
+            consumer.event("final", 789, listOf())
         }
     }
 

--- a/traceevents/src/test/java/com/tomtom/kotlin/traceevents/TestUtils.kt
+++ b/traceevents/src/test/java/com/tomtom/kotlin/traceevents/TestUtils.kt
@@ -24,27 +24,6 @@ import java.io.ByteArrayOutputStream
 import java.io.PrintStream
 import kotlin.reflect.jvm.jvmName
 
-/**
- * Utility function to check if a trace events matches the given parameters.
- */
-fun MockKMatcherScope.traceEq(
-    context: String,
-    traceThreadLocalContext: Map<String, Any?>? = null,
-    logLevel: LogLevel,
-    functionName: String,
-    vararg args: Any
-) =
-    match<TraceEvent> { traceEvent ->
-
-        traceEvent.logLevel == logLevel &&
-                traceEvent.taggingClassName == TracerTest::class.jvmName &&
-                traceEvent.context == context &&
-                traceEvent.traceThreadLocalContext == traceThreadLocalContext &&
-                traceEvent.interfaceName == TracerTest.MyEvents::class.jvmName &&
-                traceEvent.eventName == functionName &&
-                traceEvent.args.map { it?.javaClass } == args.map { it.javaClass } &&
-                traceEvent.args.contentDeepEquals(args)
-    }
 
 /**
  * Function to capture stdout output to a string.

--- a/traceevents/src/test/java/com/tomtom/kotlin/traceevents/TracerTest.kt
+++ b/traceevents/src/test/java/com/tomtom/kotlin/traceevents/TracerTest.kt
@@ -71,33 +71,6 @@ class TracerTest {
             TraceLog.log(LogLevel.WARN, "TAG", "w()")
     }
 
-    companion object {
-        val TAG = TracerTest::class.simpleName
-        val sut = Tracer.Factory.create<MyEvents>(this)
-        val sutMain = Tracer.Factory.create<MyEvents>(this, "the main tracer")
-        val sutOther = Tracer.Factory.create<MyEvents>(this, "another tracer")
-        val sutWrong = Tracer.Factory.create<WrongListener>(this)
-        val sutWithoutToString = Tracer.Factory.create<ListenerWithoutToString>(this)
-
-        fun MockKMatcherScope.traceEq(
-            context: String,
-            traceThreadLocalContext: Map<String, Any?>? = null,
-            logLevel: LogLevel,
-            functionName: String,
-            vararg args: Any
-        ) =
-            match<TraceEvent> { traceEvent ->
-                traceEvent.logLevel == logLevel &&
-                        traceEvent.taggingClassName == TracerTest::class.jvmName &&
-                        traceEvent.context == context &&
-                        traceEvent.traceThreadLocalContext == traceThreadLocalContext &&
-                        traceEvent.interfaceName == MyEvents::class.jvmName &&
-                        traceEvent.eventName == functionName &&
-                        traceEvent.args.map { it?.javaClass } == args.map { it.javaClass } &&
-                        traceEvent.args.contentDeepEquals(args)
-            }
-    }
-
     @Before
     fun setUp() {
         setUpTracerTest()
@@ -198,9 +171,39 @@ class TracerTest {
         coVerifySequence {
             consumer.consumeTraceEvent(traceEq("", null, LogLevel.DEBUG, "eventNoArgs"))
             consumer.consumeTraceEvent(traceEq("", null, LogLevel.DEBUG, "eventString", "xyz"))
-            consumer.consumeTraceEvent(traceEq("", null, LogLevel.ERROR, "eventIntsString", 10, 20, "abc"))
-            consumer.consumeTraceEvent(traceEq("", null, LogLevel.ERROR, "eventIntsString", 10, 20, "abc"))
-            consumer.consumeTraceEvent(traceEq("", null, LogLevel.ERROR, "eventIntsString", 10, 20, "abc"))
+            consumer.consumeTraceEvent(
+                traceEq(
+                    "",
+                    null,
+                    LogLevel.ERROR,
+                    "eventIntsString",
+                    10,
+                    20,
+                    "abc"
+                )
+            )
+            consumer.consumeTraceEvent(
+                traceEq(
+                    "",
+                    null,
+                    LogLevel.ERROR,
+                    "eventIntsString",
+                    10,
+                    20,
+                    "abc"
+                )
+            )
+            consumer.consumeTraceEvent(
+                traceEq(
+                    "",
+                    null,
+                    LogLevel.ERROR,
+                    "eventIntsString",
+                    10,
+                    20,
+                    "abc"
+                )
+            )
         }
     }
 
@@ -217,7 +220,15 @@ class TracerTest {
 
         // THEN
         coVerifySequence {
-            consumer.consumeTraceEvent(traceEq("the main tracer", null, LogLevel.DEBUG, "eventString", "xyz"))
+            consumer.consumeTraceEvent(
+                traceEq(
+                    "the main tracer",
+                    null,
+                    LogLevel.DEBUG,
+                    "eventString",
+                    "xyz"
+                )
+            )
         }
     }
 
@@ -253,7 +264,14 @@ class TracerTest {
         // THEN
         coVerifySequence {
             consumer.consumeTraceEvent(traceEq("", null, LogLevel.DEBUG, "eventNoArgs"))
-            consumer.consumeTraceEvent(traceEq("", HashMap(mapOf("id" to 123)), LogLevel.DEBUG, "eventNoArgs"))
+            consumer.consumeTraceEvent(
+                traceEq(
+                    "",
+                    HashMap(mapOf("id" to 123)),
+                    LogLevel.DEBUG,
+                    "eventNoArgs"
+                )
+            )
         }
     }
 
@@ -543,5 +561,32 @@ class TracerTest {
     @Test
     fun `equals and hashCode`() {
         EqualsVerifier.forClass(TraceEvent::class.java).verify()
+    }
+
+    companion object {
+        val TAG = TracerTest::class.simpleName
+        val sut = Tracer.Factory.create<MyEvents>(this)
+        val sutMain = Tracer.Factory.create<MyEvents>(this, "the main tracer")
+        val sutOther = Tracer.Factory.create<MyEvents>(this, "another tracer")
+        val sutWrong = Tracer.Factory.create<WrongListener>(this)
+        val sutWithoutToString = Tracer.Factory.create<ListenerWithoutToString>(this)
+
+        fun MockKMatcherScope.traceEq(
+            context: String,
+            traceThreadLocalContext: Map<String, Any?>? = null,
+            logLevel: LogLevel,
+            functionName: String,
+            vararg args: Any
+        ) =
+            match<TraceEvent> { traceEvent ->
+                traceEvent.logLevel == logLevel &&
+                    traceEvent.taggingClassName == TracerTest::class.jvmName &&
+                    traceEvent.context == context &&
+                    traceEvent.traceThreadLocalContext == traceThreadLocalContext &&
+                    traceEvent.interfaceName == MyEvents::class.jvmName &&
+                    traceEvent.eventName == functionName &&
+                    traceEvent.args.map { it?.javaClass } == args.map { it.javaClass } &&
+                    traceEvent.args.contentDeepEquals(args)
+            }
     }
 }

--- a/traceevents/src/test/java/com/tomtom/kotlin/traceevents/TracerTest.kt
+++ b/traceevents/src/test/java/com/tomtom/kotlin/traceevents/TracerTest.kt
@@ -92,10 +92,10 @@ class TracerTest {
         // THEN
         coVerifySequence {
             consumer.eventNoArgs()
-            consumer.eventString(eq("abc"))
-            consumer.eventIntsString(eq(10), eq(20), eq("abc"))
-            consumer.eventIntsString(eq(10), eq(20), eq("abc"))
-            consumer.eventIntsString(eq(10), eq(20), eq("abc"))
+            consumer.eventString("abc")
+            consumer.eventIntsString(10, 20, "abc")
+            consumer.eventIntsString(10, 20, "abc")
+            consumer.eventIntsString(10, 20, "abc")
         }
     }
 
@@ -113,8 +113,8 @@ class TracerTest {
         // THEN
         coVerifySequence {
             consumer.eventNoArgs()
-            consumer.eventString(eq("abc"))
-            consumer.eventIntsString(eq(10), eq(20), eq("abc"))
+            consumer.eventString("abc")
+            consumer.eventIntsString(10, 20, "abc")
         }
     }
 
@@ -131,7 +131,7 @@ class TracerTest {
 
         // THEN
         coVerifySequence {
-            consumer.eventString(eq("abc"))
+            consumer.eventString("abc")
         }
     }
 
@@ -351,8 +351,8 @@ class TracerTest {
         // THEN
         coVerifySequence {
             consumer.eventNoArgs()
-            consumer.eventString(eq("abc"))
-            consumer.eventIntsString(eq(10), eq(20), eq("abc"))
+            consumer.eventString("abc")
+            consumer.eventIntsString(10, 20, "abc")
         }
 
         // WHEN
@@ -378,12 +378,12 @@ class TracerTest {
         // THEN
         coVerifySequence {
             consumer.eventNoArgs()
-            consumer.eventString(eq("abc"))
-            consumer.eventIntsString(eq(10), eq(20), eq("abc"))
+            consumer.eventString("abc")
+            consumer.eventIntsString(10, 20, "abc")
 
             // Make sure we only have the last added events here.
             consumer.equals(consumer)   // <-- This call is added because `remove` uses it.
-            consumer.eventIntsString(eq(11), eq(22), eq("xyz"))
+            consumer.eventIntsString(11, 22, "xyz")
         }
     }
 
@@ -401,9 +401,9 @@ class TracerTest {
 
         // THEN
         verifySequence {
-            consumer.d(eq("abc"))
-            consumer.d(eq("null"), isNull())
-            consumer.d(eq("non-null"), eq(e))
+            consumer.d("abc")
+            consumer.d("null", isNull())
+            consumer.d("non-null", e)
         }
     }
 
@@ -425,11 +425,11 @@ class TracerTest {
             consumer.incorrectLogSignatureFound()
             consumer.v()
             consumer.incorrectLogSignatureFound()
-            consumer.d(eq(1))
+            consumer.d(1)
             consumer.incorrectLogSignatureFound()
-            consumer.i(eq("test"), eq(2))
+            consumer.i("test", 2)
             consumer.incorrectLogSignatureFound()
-            consumer.w(eq("test"), eq(e), 3)
+            consumer.w("test", e, 3)
         }
     }
 
@@ -446,9 +446,9 @@ class TracerTest {
 
         // THEN
         verifySequence {
-            consumer.eventNullable(eq(1))
+            consumer.eventNullable(1)
             consumer.eventNullable(isNull())
-            consumer.eventNullable(eq(2))
+            consumer.eventNullable(2)
         }
     }
 
@@ -466,10 +466,10 @@ class TracerTest {
 
         // THEN
         verifySequence {
-            consumer.eventList(eq(listOf<Int?>(1, 2)))
-            consumer.eventList(eq(listOf<Int?>(3, null)))
-            consumer.eventList(eq(listOf<Int?>(null, 4)))
-            consumer.eventList(eq(listOf<Int?>(null, null)))
+            consumer.eventList(listOf<Int?>(1, 2))
+            consumer.eventList(listOf<Int?>(3, null))
+            consumer.eventList(listOf<Int?>(null, 4))
+            consumer.eventList(listOf<Int?>(null, null))
         }
     }
 
@@ -487,10 +487,10 @@ class TracerTest {
 
         // THEN
         verifySequence {
-            consumer.eventArray(eq(arrayOf<Int?>(1, 2)))
-            consumer.eventArray(eq(arrayOf<Int?>(3, null)))
-            consumer.eventArray(eq(arrayOf<Int?>(null, 4)))
-            consumer.eventArray(eq(arrayOf<Int?>(null, null)))
+            consumer.eventArray(arrayOf<Int?>(1, 2))
+            consumer.eventArray(arrayOf<Int?>(3, null))
+            consumer.eventArray(arrayOf<Int?>(null, 4))
+            consumer.eventArray(arrayOf<Int?>(null, null))
         }
     }
 
@@ -530,8 +530,8 @@ class TracerTest {
 
         // THEN
         coVerifySequence {
-            consumerWithoutToString.eventWithoutToString(eq(objectWithoutToString))
-            consumerWithoutToString.eventWithoutToString(eq(anotherObjectWithoutToString))
+            consumerWithoutToString.eventWithoutToString(objectWithoutToString)
+            consumerWithoutToString.eventWithoutToString(anotherObjectWithoutToString)
         }
     }
 

--- a/uid/pom.xml
+++ b/uid/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.kotlin</groupId>
         <artifactId>kotlin-tools</artifactId>
-        <version>1.5.0</version>
+        <version>1.5.1</version>
     </parent>
 
     <artifactId>uid</artifactId>


### PR DESCRIPTION
* Added `getParametersMap` to `TraceEvent`, which allows generic trace event consumers to access parameters and 
their values through a map that maps parameters names to their values. The other way to access parameter values
is by using `args`, which is an array with paramters values, in the order of the method declaration.  
