### PR TITLE
Reduce use of reflection on the critical path of trace events

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,9 +659,10 @@ Contributors: Timon Kanters, Jeroen Erik Jensen, Krzysztof Karczewski
 
 ## Release notes
 
-### 1.6.5
+### 1.7.0
 
-* Reduce use of reflection on critical path of trace events.
+* Reduce use of reflection on the critical path of trace events by not obtaining the trace event parameter names on the
+  thread that traces the event. Only obtain the trace event parameter names when requested by a trace event consumer.
 
 ### 1.6.4
 

--- a/README.md
+++ b/README.md
@@ -659,6 +659,10 @@ Contributors: Timon Kanters, Jeroen Erik Jensen, Krzysztof Karczewski
 
 ## Release notes
 
+### 1.6.5
+
+* Reduce use of reflection on critical path of trace events.
+
 ### 1.6.4
 
 * Updated dependencies.

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.kotlin</groupId>
         <artifactId>kotlin-tools</artifactId>
-        <version>1.6.5</version>
+        <version>1.7.0</version>
     </parent>
 
     <artifactId>extensions</artifactId>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.kotlin</groupId>
         <artifactId>kotlin-tools</artifactId>
-        <version>1.6.4</version>
+        <version>1.6.5</version>
     </parent>
 
     <artifactId>extensions</artifactId>

--- a/memoization/pom.xml
+++ b/memoization/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.kotlin</groupId>
         <artifactId>kotlin-tools</artifactId>
-        <version>1.6.5</version>
+        <version>1.7.0</version>
     </parent>
 
     <artifactId>memoization</artifactId>

--- a/memoization/pom.xml
+++ b/memoization/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.kotlin</groupId>
         <artifactId>kotlin-tools</artifactId>
-        <version>1.6.4</version>
+        <version>1.6.5</version>
     </parent>
 
     <artifactId>memoization</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>com.tomtom.kotlin</groupId>
     <artifactId>kotlin-tools</artifactId>
-    <version>1.6.4</version>
+    <version>1.6.5</version>
     <packaging>pom</packaging>
 
     <name>Kotlin Tools</name>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>com.tomtom.kotlin</groupId>
     <artifactId>kotlin-tools</artifactId>
-    <version>1.6.5</version>
+    <version>1.7.0</version>
     <packaging>pom</packaging>
 
     <name>Kotlin Tools</name>

--- a/traceevents/pom.xml
+++ b/traceevents/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.kotlin</groupId>
         <artifactId>kotlin-tools</artifactId>
-        <version>1.6.5</version>
+        <version>1.7.0</version>
     </parent>
 
     <artifactId>traceevents</artifactId>

--- a/traceevents/pom.xml
+++ b/traceevents/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.kotlin</groupId>
         <artifactId>kotlin-tools</artifactId>
-        <version>1.6.4</version>
+        <version>1.6.5</version>
     </parent>
 
     <artifactId>traceevents</artifactId>

--- a/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceEvent.kt
+++ b/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceEvent.kt
@@ -52,7 +52,7 @@ public data class TraceEvent(
      * to access the parameters names and values. If `null` the map could not be created for some reason.
      * You can still use the `args` array in that case.
      *
-     * Obtaining the parameters names requires reflection.
+     * Obtaining the parameters names requires reflection. Do not use when performance is critical.
      */
     @Suppress("MemberVisibilityCanBePrivate")
     val parameterNames: Array<String>? by lazy {
@@ -66,7 +66,7 @@ public data class TraceEvent(
      * Returns an empty map for parameterless methods and `null` if 1 or more parameter names are
      * not available for some reason.
      *
-     * Obtaining the parameters names requires reflection.
+     * Obtaining the parameters names requires reflection. Do not use when performance is critical.
      */
     public fun getNamedParametersMap(): Map<String, Any?>? =
         parameterNames?.let { parameterNames ->

--- a/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceEvent.kt
+++ b/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceEvent.kt
@@ -31,9 +31,8 @@ import java.time.LocalDateTime
  * @param stackTraceHolder Throwable from which a stack trace can be produced. `null` when unavailable.
  * @param eventName Function name in interface, which represents the trace event name.
  * @param args Trace event arguments. Specified as array, to avoid expensive array/list conversions.
- * @param parameterNames Names of the parameters, in the same order as the `args` values. Normally, you would use
- * `getNamedParametersMap` to access the parameters names and values. If `null` the map could not be created for some reason.
- * You can still use the `args` array in that case.
+ * @param parameterNamesProvider Provides the names of the parameters, in the same order as the `args` values.
+ *   See [parameterNames] and [getNamedParametersMap].
  */
 public data class TraceEvent(
     val dateTime: LocalDateTime,
@@ -46,19 +45,33 @@ public data class TraceEvent(
     val stackTraceHolder: Throwable?,
     val eventName: String,
     val args: Array<Any?>,
-    val parameterNames: Array<String>?
+    internal val parameterNamesProvider: () -> Array<String>?
 ) {
-    init {
-        check(parameterNames == null || args.size == parameterNames.size)
+    /**
+     * Names of the parameters, in the same order as the `args` values. Normally, you would use [getNamedParametersMap]
+     * to access the parameters names and values. If `null` the map could not be created for some reason.
+     * You can still use the `args` array in that case.
+     *
+     * Obtaining the parameters names requires reflection.
+     */
+    @Suppress("MemberVisibilityCanBePrivate")
+    val parameterNames: Array<String>? by lazy {
+        parameterNamesProvider.invoke().also {
+            check(it == null || args.size == it.size)
+        }
     }
 
     /**
      * Gets the method parameters as a map that maps the parameter name to its value.
      * Returns an empty map for parameterless methods and `null` if 1 or more parameter names are
      * not available for some reason.
+     *
+     * Obtaining the parameters names requires reflection.
      */
     public fun getNamedParametersMap(): Map<String, Any?>? =
-        parameterNames?.indices?.associateBy({ parameterNames[it] }, { args[it] })
+        parameterNames?.let { parameterNames ->
+            parameterNames.indices.associateBy({ parameterNames[it] }, { args[it] })
+        }
 
     /**
      * Need to override the `equals` and `hashCode` functions, as the class contains
@@ -80,7 +93,7 @@ public data class TraceEvent(
         if (stackTraceHolder != other.stackTraceHolder) return false
         if (eventName != other.eventName) return false
         if (!args.contentDeepEquals(other.args)) return false
-        if (!parameterNames.contentEquals(other.parameterNames)) return false
+        if (parameterNamesProvider != other.parameterNamesProvider) return false
         return true
     }
 
@@ -95,7 +108,7 @@ public data class TraceEvent(
         result = 31 * result + (stackTraceHolder?.hashCode() ?: 0)
         result = 31 * result + eventName.hashCode()
         result = 31 * result + args.contentDeepHashCode()
-        result = 31 * result + parameterNames.contentHashCode()
+        result = 31 * result + parameterNamesProvider.hashCode()
         return result
     }
 }

--- a/traceevents/src/main/java/com/tomtom/kotlin/traceevents/Tracer.kt
+++ b/traceevents/src/main/java/com/tomtom/kotlin/traceevents/Tracer.kt
@@ -318,9 +318,10 @@ public class Tracer private constructor(
             args = args ?: arrayOf(),
             parameterNamesProvider = {
                 /**
-                 * Get the parameter names for the method.
-                 * For performance reasons, make sure this code is normally executed only once per method call. Note
-                 * that this method may be called by multiple threads, so it must be thread-safe as well.
+                 * Get the parameter names for the trace event method.
+                 * For performance reasons, make sure this code is normally executed only once per trace event method
+                 * and only when the parameter names a requested by a trace event consumer. Note that this lambda may be
+                 * called by multiple threads, so it must be thread-safe as well.
                  * Also make sure the parameter names are only provided if there is exactly 1 name for each parameter
                  * only.
                  */

--- a/traceevents/src/main/java/com/tomtom/kotlin/traceevents/Tracer.kt
+++ b/traceevents/src/main/java/com/tomtom/kotlin/traceevents/Tracer.kt
@@ -277,7 +277,7 @@ public class Tracer private constructor(
      * overhead for the system. Any actions taken as a result of the event should be scheduled onto
      * another thread (and throttled if needed).
      *
-     * @param proxy Proxied object.
+     * @param proxy Proxy object.
      * @param method Method being called.
      * @param args Additional arguments to method, may be null.
      * @return Always null; the signature of events functions must be void/Unit.
@@ -303,19 +303,6 @@ public class Tracer private constructor(
             return null
         }
 
-        /**
-         * Get the parameter names for the method.
-         * For performance reasons, make sure this code is normally executed only once per method call. Note that
-         * this method may be called by multiple threads, so it must be thread-safe as well.
-         * Also make sure the parameter names are only provided if there is exactly 1 name for each parameter only.
-         */
-        val parameterNames = parameterNamesCache[method] ?: method.kotlinFunction
-            ?.parameters
-            ?.mapNotNull { it.name }
-            ?.takeIf { it.size == args?.size }
-            ?.toTypedArray()
-            ?.also { parameterNamesCache[method] = it }
-
         // Send the event to the event processor consumer, non-blocking.
         val now = LocalDateTime.now()
         val event = TraceEvent(
@@ -329,7 +316,21 @@ public class Tracer private constructor(
             stackTraceHolder = Throwable(),
             eventName = method.name,
             args = args ?: arrayOf(),
-            parameterNames = parameterNames
+            parameterNamesProvider = {
+                /**
+                 * Get the parameter names for the method.
+                 * For performance reasons, make sure this code is normally executed only once per method call. Note
+                 * that this method may be called by multiple threads, so it must be thread-safe as well.
+                 * Also make sure the parameter names are only provided if there is exactly 1 name for each parameter
+                 * only.
+                 */
+                parameterNamesCache[method] ?: method.kotlinFunction
+                    ?.parameters
+                    ?.mapNotNull { it.name }
+                    ?.takeIf { it.size == args?.size }
+                    ?.toTypedArray()
+                    ?.also { parameterNamesCache[method] = it }
+            }
         )
 
         /**

--- a/traceevents/src/test/java/com/tomtom/kotlin/traceevents/TraceEventTest.kt
+++ b/traceevents/src/test/java/com/tomtom/kotlin/traceevents/TraceEventTest.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2012-2022, TomTom (http://tomtom.com).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.tomtom.kotlin.traceevents
 
 import io.mockk.every

--- a/traceevents/src/test/java/com/tomtom/kotlin/traceevents/TraceEventTest.kt
+++ b/traceevents/src/test/java/com/tomtom/kotlin/traceevents/TraceEventTest.kt
@@ -1,0 +1,117 @@
+package com.tomtom.kotlin.traceevents
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import nl.jqno.equalsverifier.EqualsVerifier
+import org.junit.Test
+import java.time.LocalDateTime
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+
+internal class TraceEventTest {
+
+    @Test
+    fun `parameterNames invokes parameterNamesProvider with lazy`() {
+        // GIVEN
+        val parameterNamesProvider = mockk<() -> Array<String>?>()
+        every { parameterNamesProvider.invoke() } returns arrayOf("parameterName1", "parameterName2")
+
+        val sut = createSut(parameterNamesProvider)
+
+        // THEN
+        verify(exactly = 0) { parameterNamesProvider.invoke() }
+
+        // WHEN
+        val parameterNames = sut.parameterNames
+
+        // THEN
+        verify(exactly = 1) { parameterNamesProvider.invoke() }
+        assertEquals(arrayOf("parameterName1", "parameterName2").toList(), parameterNames?.toList())
+    }
+
+    @Test
+    fun `getNamedParametersMap invokes parameterNamesProvider with lazy`() {
+        // GIVEN
+        val parameterNamesProvider = mockk<() -> Array<String>?>()
+        every { parameterNamesProvider.invoke() } returns arrayOf("parameterName1", "parameterName2")
+
+        val sut = createSut(parameterNamesProvider)
+
+        // THEN
+        verify(exactly = 0) { parameterNamesProvider.invoke() }
+
+        // WHEN
+        val namedParameters = sut.getNamedParametersMap()
+
+        // THEN
+        verify(exactly = 1) { parameterNamesProvider.invoke() }
+        assertEquals(mapOf("parameterName1" to "value1", "parameterName2" to "value2"), namedParameters)
+    }
+
+    @Test
+    fun `parameterNames checks number of parameters`() {
+        // GIVEN
+        val parameterNamesProvider = mockk<() -> Array<String>?>()
+        every { parameterNamesProvider.invoke() } returns arrayOf("parameterName1")
+
+        val sut = createSut(parameterNamesProvider)
+
+        // WHEN - THEN
+        assertFailsWith<IllegalStateException> {
+            sut.parameterNames
+        }
+    }
+
+    @Test
+    fun `getNamedParametersMap checks number of parameters`() {
+        // GIVEN
+        val parameterNamesProvider = mockk<() -> Array<String>?>()
+        every { parameterNamesProvider.invoke() } returns arrayOf("parameterName1")
+
+        val sut = createSut(parameterNamesProvider)
+
+        // WHEN - THEN
+        assertFailsWith<IllegalStateException> {
+            sut.getNamedParametersMap()
+        }
+    }
+
+    @Test
+    fun `getNamedParametersMap returns null if parameterNamesProvider returns null`() {
+        // GIVEN
+        val parameterNamesProvider = mockk<() -> Array<String>?>()
+        every { parameterNamesProvider.invoke() } returns null
+
+        val sut = createSut(parameterNamesProvider)
+
+        // WHEN
+        val namedParameters = sut.getNamedParametersMap()
+
+        // THEN
+        assertNull(namedParameters)
+    }
+
+    @Test
+    fun `equals and hashCode`() {
+        EqualsVerifier.forClass(TraceEvent::class.java)
+            .withIgnoredFields("${TraceEvent::parameterNames.name}\$delegate")
+            .verify()
+    }
+
+    private fun createSut(parameterNamesProvider: () -> Array<String>?) =
+        TraceEvent(
+            dateTime = LocalDateTime.now(),
+            logLevel = TraceLog.LogLevel.DEBUG,
+            tracerClassName = "TracerClassName",
+            taggingClassName = "TaggingClass",
+            context = "Context",
+            traceThreadLocalContext = emptyMap(),
+            interfaceName = "InterfaceName",
+            stackTraceHolder = null,
+            eventName = "EventName",
+            args = arrayOf("value1", "value2"),
+            parameterNamesProvider = parameterNamesProvider
+        )
+}

--- a/traceevents/src/test/java/com/tomtom/kotlin/traceevents/TracerTest.kt
+++ b/traceevents/src/test/java/com/tomtom/kotlin/traceevents/TracerTest.kt
@@ -52,8 +52,9 @@ internal class TracerTest {
     }
 
     class GenericConsumer : GenericTraceEventConsumer, TraceEventConsumer {
-        override suspend fun consumeTraceEvent(traceEvent: TraceEvent) =
+        override suspend fun consumeTraceEvent(traceEvent: TraceEvent) {
             TraceLog.log(LogLevel.DEBUG, "TAG", traceEvent.eventName)
+        }
     }
 
     interface WrongListener : TraceEventListener {
@@ -382,6 +383,7 @@ internal class TracerTest {
             consumer.eventIntsString(10, 20, "abc")
 
             // Make sure we only have the last added events here.
+            @Suppress("ReplaceCallWithBinaryOperator", "UnusedEquals")
             consumer.equals(consumer)   // <-- This call is added because `remove` uses it.
             consumer.eventIntsString(11, 22, "xyz")
         }
@@ -556,11 +558,6 @@ internal class TracerTest {
     fun `register toString for SomeClass`() {
         Tracer.registerToString<SomeClass> { "x=$x" }
         assertEquals("x=10", Tracer.convertToStringUsingRegistry(SomeClass()))
-    }
-
-    @Test
-    fun `equals and hashCode`() {
-        EqualsVerifier.forClass(TraceEvent::class.java).verify()
     }
 
     companion object {

--- a/traceevents/src/test/java/com/tomtom/kotlin/traceevents/TracerTest.kt
+++ b/traceevents/src/test/java/com/tomtom/kotlin/traceevents/TracerTest.kt
@@ -52,9 +52,8 @@ internal class TracerTest {
     }
 
     class GenericConsumer : GenericTraceEventConsumer, TraceEventConsumer {
-        override suspend fun consumeTraceEvent(traceEvent: TraceEvent) {
+        override suspend fun consumeTraceEvent(traceEvent: TraceEvent) =
             TraceLog.log(LogLevel.DEBUG, "TAG", traceEvent.eventName)
-        }
     }
 
     interface WrongListener : TraceEventListener {

--- a/uid/pom.xml
+++ b/uid/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.kotlin</groupId>
         <artifactId>kotlin-tools</artifactId>
-        <version>1.6.4</version>
+        <version>1.6.5</version>
     </parent>
 
     <artifactId>uid</artifactId>

--- a/uid/pom.xml
+++ b/uid/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.kotlin</groupId>
         <artifactId>kotlin-tools</artifactId>
-        <version>1.6.5</version>
+        <version>1.7.0</version>
     </parent>
 
     <artifactId>uid</artifactId>


### PR DESCRIPTION
Obtaining parameter names from a method requires reflection, including parsing the Kotlin metadata. Parameter names are not used by default. Obtain the parameter names only if requested by a trace event consumer to reduce the use of reflection on the performance critical path of trace events.