### PR TITLE
Tracer performance and documentation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -662,7 +662,7 @@ Contributors: Timon Kanters, Jeroen Erik Jensen, Krzysztof Karczewski
 ### 1.7.1
 
 * Remove use of reflection on the critical path of creating a `Tracer` object by removing the use of
-  `KClass<*>.isCompanion`. Use top level enclosing class for the tagging class instead.
+  `KClass<*>.isCompanion`. Remove the `$Companion` suffix from the tagging class instead.
 * Initialize `Tracer` library faster by removing the use of reflection to obtain Tracer library class names.
 * Replace the use of `LocalDateTime` with `Instant` to measure elapsed time. This omits loading timezone data during
   initialization of the `Tracer` library.

--- a/README.md
+++ b/README.md
@@ -659,6 +659,15 @@ Contributors: Timon Kanters, Jeroen Erik Jensen, Krzysztof Karczewski
 
 ## Release notes
 
+### 1.7.1
+
+* Remove use of reflection on the critical path of creating a `Tracer` object by removing the use of
+  `KClass<*>.isCompanion`. Use top level enclosing class for the tagging class instead.
+* Initialize `Tracer` library faster by removing the use of reflection to obtain Tracer library class names.
+* Replace the use of `LocalDateTime` with `Instant` to measure elapsed time. This omits loading timezone data during
+  initialization of the `Tracer` library.
+* Improve documentation of `TracerEvent.parameterNamesProvider`.
+
 ### 1.7.0
 
 * Reduce use of reflection on the critical path of trace events by not obtaining the trace event parameter names on the

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.kotlin</groupId>
         <artifactId>kotlin-tools</artifactId>
-        <version>1.7.0</version>
+        <version>1.7.1</version>
     </parent>
 
     <artifactId>extensions</artifactId>

--- a/memoization/pom.xml
+++ b/memoization/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.kotlin</groupId>
         <artifactId>kotlin-tools</artifactId>
-        <version>1.7.0</version>
+        <version>1.7.1</version>
     </parent>
 
     <artifactId>memoization</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>com.tomtom.kotlin</groupId>
     <artifactId>kotlin-tools</artifactId>
-    <version>1.7.0</version>
+    <version>1.7.1</version>
     <packaging>pom</packaging>
 
     <name>Kotlin Tools</name>

--- a/traceevents/pom.xml
+++ b/traceevents/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.kotlin</groupId>
         <artifactId>kotlin-tools</artifactId>
-        <version>1.7.0</version>
+        <version>1.7.1</version>
     </parent>
 
     <artifactId>traceevents</artifactId>

--- a/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceEvent.kt
+++ b/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceEvent.kt
@@ -32,6 +32,7 @@ import java.time.LocalDateTime
  * @param eventName Function name in interface, which represents the trace event name.
  * @param args Trace event arguments. Specified as array, to avoid expensive array/list conversions.
  * @param parameterNamesProvider Provides the names of the parameters, in the same order as the `args` values.
+ *   The provider can return `null` to indicate that the parameters names could not be created for some reason.
  *   See [parameterNames] and [getNamedParametersMap].
  */
 public data class TraceEvent(

--- a/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceEventConsumerCollection.kt
+++ b/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceEventConsumerCollection.kt
@@ -265,7 +265,7 @@ public class TraceEventConsumerCollection {
      */
     private val traceEventFunctions = HashMap<Key, Method>()
 
-    private companion object {
+    internal companion object {
         const val TAG = "TraceEventConsumerCollection"
     }
 }

--- a/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceEventConsumerCollection.kt
+++ b/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceEventConsumerCollection.kt
@@ -266,6 +266,6 @@ public class TraceEventConsumerCollection {
     private val traceEventFunctions = HashMap<Key, Method>()
 
     private companion object {
-        val TAG = TraceEventConsumerCollection::class.simpleName!!
+        const val TAG = "TraceEventConsumerCollection"
     }
 }

--- a/traceevents/src/main/java/com/tomtom/kotlin/traceevents/Tracer.kt
+++ b/traceevents/src/main/java/com/tomtom/kotlin/traceevents/Tracer.kt
@@ -472,7 +472,7 @@ public class Tracer private constructor(
     }
 
     public companion object {
-        private const val TAG = "Tracer"
+        internal const val TAG = "Tracer"
         private const val STACK_TRACE_DEPTH = 5L
 
         /**

--- a/traceevents/src/main/java/com/tomtom/kotlin/traceevents/Tracer.kt
+++ b/traceevents/src/main/java/com/tomtom/kotlin/traceevents/Tracer.kt
@@ -23,6 +23,7 @@ import java.io.StringWriter
 import java.lang.reflect.InvocationHandler
 import java.lang.reflect.Method
 import java.lang.reflect.Proxy
+import java.time.Instant
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.concurrent.ConcurrentHashMap
@@ -251,23 +252,19 @@ public class Tracer private constructor(
                 require(isLoggerOnly || traceEventListener != TraceEventListener::class) {
                     "Derive an interface from TraceEventListener, or use createLoggerOnly()"
                 }
-                val taggingClassTopLevel =
-                    if (taggingClass.isCompanion) {
-                        // Don't use the companion object class, but the top-level class.
-                        taggingClass.javaObjectType.enclosingClass?.kotlin!!
-                    } else {
-                        taggingClass.javaObjectType.kotlin
-                    }
                 return Proxy.newProxyInstance(
                     traceEventListener.java.classLoader,
                     arrayOf<Class<*>?>(traceEventListener.java),
                     Tracer(
                         tracerClassName = tracerClassName,
-                        taggingClassName = taggingClassTopLevel.jvmName,
+                        taggingClassName = taggingClass.topLevelEnclosingClassOrThis.jvmName,
                         context = context
                     )
                 ) as T
             }
+
+            private val KClass<*>.topLevelEnclosingClassOrThis: KClass<*>
+                get() = javaObjectType.enclosingClass?.kotlin?.topLevelEnclosingClassOrThis ?: this
         }
     }
 
@@ -364,7 +361,7 @@ public class Tracer private constructor(
                 )
             }
         }
-        offerTraceEvent(event, now)
+        offerTraceEvent(event)
         return null
     }
 
@@ -398,10 +395,7 @@ public class Tracer private constructor(
      * Offer [event] to the processing queue. If trace logging is set to [LoggingMode.SYNC], this
      * function also outputs the trace using a logger, in this thread.
      */
-    private fun offerTraceEvent(
-        event: TraceEvent,
-        now: LocalDateTime?
-    ) {
+    private fun offerTraceEvent(event: TraceEvent) {
         if (!traceEventChannel.trySend(event).isSuccess) {
             when (loggingMode) {
                 LoggingMode.SYNC ->
@@ -439,6 +433,7 @@ public class Tracer private constructor(
         }
 
         // If we lost events, write a log message to indicate so, but at most once every x seconds.
+        val now = Instant.now()
         if (nrLostTraceEventsSinceLastMsg > 0 &&
             timeLastLostTraceEvent.plusSeconds(LIMIT_WARN_SECS).isBefore(now)
         ) {
@@ -477,7 +472,7 @@ public class Tracer private constructor(
     }
 
     public companion object {
-        private val TAG = Tracer::class.simpleName!!
+        private const val TAG = "Tracer"
         private const val STACK_TRACE_DEPTH = 5L
 
         /**
@@ -532,7 +527,7 @@ public class Tracer private constructor(
         private const val LIMIT_WARN_SECS = 10L
         private var nrLostTraceEventsSinceLastMsg = 0L
         private var nrLostTraceEventsTotal = 0L
-        private var timeLastLostTraceEvent = LocalDateTime.now().minusSeconds(LIMIT_WARN_SECS)
+        private var timeLastLostTraceEvent = Instant.now().minusSeconds(LIMIT_WARN_SECS)
 
         /**
          * Registry of [toString] functions for classes, to be used instead of their own variants.

--- a/traceevents/src/main/java/com/tomtom/kotlin/traceevents/Tracer.kt
+++ b/traceevents/src/main/java/com/tomtom/kotlin/traceevents/Tracer.kt
@@ -257,14 +257,11 @@ public class Tracer private constructor(
                     arrayOf<Class<*>?>(traceEventListener.java),
                     Tracer(
                         tracerClassName = tracerClassName,
-                        taggingClassName = taggingClass.topLevelEnclosingClassOrThis.jvmName,
+                        taggingClassName = taggingClass.jvmName.removeSuffix("\$Companion"),
                         context = context
                     )
                 ) as T
             }
-
-            private val KClass<*>.topLevelEnclosingClassOrThis: KClass<*>
-                get() = javaObjectType.enclosingClass?.kotlin?.topLevelEnclosingClassOrThis ?: this
         }
     }
 

--- a/traceevents/src/test/java/com/tomtom/kotlin/traceevents/TraceEventConsumerCollectionTest.kt
+++ b/traceevents/src/test/java/com/tomtom/kotlin/traceevents/TraceEventConsumerCollectionTest.kt
@@ -1,0 +1,15 @@
+package com.tomtom.kotlin.traceevents
+
+import org.junit.Test
+import kotlin.test.assertEquals
+
+internal class TraceEventConsumerCollectionTest {
+
+    @Test
+    fun `TAG matches class name`() {
+        assertEquals(
+            TraceEventConsumerCollection::class.simpleName,
+            TraceEventConsumerCollection.TAG
+        )
+    }
+}

--- a/traceevents/src/test/java/com/tomtom/kotlin/traceevents/TracerTest.kt
+++ b/traceevents/src/test/java/com/tomtom/kotlin/traceevents/TracerTest.kt
@@ -559,6 +559,11 @@ internal class TracerTest {
         assertEquals("x=10", Tracer.convertToStringUsingRegistry(SomeClass()))
     }
 
+    @Test
+    fun `TAG matches class name`() {
+        assertEquals(Tracer::class.simpleName, Tracer.TAG)
+    }
+
     companion object {
         val sut = Tracer.Factory.create<MyEvents>(this)
         val sutMain = Tracer.Factory.create<MyEvents>(this, "the main tracer")

--- a/uid/pom.xml
+++ b/uid/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.kotlin</groupId>
         <artifactId>kotlin-tools</artifactId>
-        <version>1.7.0</version>
+        <version>1.7.1</version>
     </parent>
 
     <artifactId>uid</artifactId>


### PR DESCRIPTION
* Remove use of reflection on the critical path of creating a `Tracer` object by removing the use of
  `KClass<*>.isCompanion`. Remove the `$Companion` suffix from the tagging class name instead.
* Initialize `Tracer` library faster by removing the use of reflection to obtain Tracer library class names.
* Replace the use of `LocalDateTime` with `Instant` to measure elapsed time. This omits loading timezone data during
  initialization of the `Tracer` library.
* Improve documentation of `TracerEvent.parameterNamesProvider`.

Update version to 1.7.1.