### PR TITLE
Fixed documentation issue on logging sync/async by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,6 +659,10 @@ Contributors: Timon Kanters, Jeroen Erik Jensen, Krzysztof Karczewski
 
 ## Release notes
 
+### 1.7.2
+
+* Fixed documentation on logging sync instead of async by default. No functional change.
+
 ### 1.7.1
 
 * Remove use of reflection on the critical path of creating a `Tracer` object by removing the use of

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.kotlin</groupId>
         <artifactId>kotlin-tools</artifactId>
-        <version>1.7.1</version>
+        <version>1.7.2</version>
     </parent>
 
     <artifactId>extensions</artifactId>

--- a/memoization/pom.xml
+++ b/memoization/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.kotlin</groupId>
         <artifactId>kotlin-tools</artifactId>
-        <version>1.7.1</version>
+        <version>1.7.2</version>
     </parent>
 
     <artifactId>memoization</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>com.tomtom.kotlin</groupId>
     <artifactId>kotlin-tools</artifactId>
-    <version>1.7.1</version>
+    <version>1.7.2</version>
     <packaging>pom</packaging>
 
     <name>Kotlin Tools</name>

--- a/traceevents/pom.xml
+++ b/traceevents/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.kotlin</groupId>
         <artifactId>kotlin-tools</artifactId>
-        <version>1.7.1</version>
+        <version>1.7.2</version>
     </parent>
 
     <artifactId>traceevents</artifactId>

--- a/traceevents/src/main/java/com/tomtom/kotlin/traceevents/Tracer.kt
+++ b/traceevents/src/main/java/com/tomtom/kotlin/traceevents/Tracer.kt
@@ -634,7 +634,7 @@ public class Tracer private constructor(
         /**
          * Set trace logging to sync (events are logged to logger in same thread as event caller)
          * or async (events are queued and logged in a separate thread).
-         * Default is async, so event processing doesn't get in the way of the caller thread.
+         * Default is sync (so events and calls to a logger are traced in order).
          */
         public fun setTraceEventLoggingMode(loggingMode: LoggingMode) {
             this.loggingMode = loggingMode

--- a/uid/pom.xml
+++ b/uid/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.kotlin</groupId>
         <artifactId>kotlin-tools</artifactId>
-        <version>1.7.1</version>
+        <version>1.7.2</version>
     </parent>
 
     <artifactId>uid</artifactId>


### PR DESCRIPTION
Fixed documentation issue on logging sync/async by default.
This version will likely not be released to Maven Central, but is just filed to include the documentation fix.