### PR TITLE
Added Tracer.hasQueuedTraceEvents

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,6 +659,10 @@ Contributors: Timon Kanters, Jeroen Erik Jensen, Krzysztof Karczewski
 
 ## Release notes
 
+### 1.8.0
+
+* Added `Tracer.hasQueuedTraceEvents: Boolean` to support testing that certain trace events were _not_ sent.
+
 ### 1.7.2
 
 * Fixed documentation on logging sync instead of async by default. No functional change.

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.kotlin</groupId>
         <artifactId>kotlin-tools</artifactId>
-        <version>1.7.2</version>
+        <version>1.8.0</version>
     </parent>
 
     <artifactId>extensions</artifactId>

--- a/memoization/pom.xml
+++ b/memoization/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.kotlin</groupId>
         <artifactId>kotlin-tools</artifactId>
-        <version>1.7.2</version>
+        <version>1.8.0</version>
     </parent>
 
     <artifactId>memoization</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -345,6 +345,12 @@
                 <artifactId>maven-project-info-reports-plugin</artifactId>
                 <version>${maven-project-info-reports-plugin.version}</version>
             </dependency>
+
+            <dependency>
+                <groupId>org.jetbrains.kotlinx</groupId>
+                <artifactId>kotlinx-coroutines-test</artifactId>
+                <version>${kotlinx-coroutines-core.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>com.tomtom.kotlin</groupId>
     <artifactId>kotlin-tools</artifactId>
-    <version>1.7.2</version>
+    <version>1.8.0</version>
     <packaging>pom</packaging>
 
     <name>Kotlin Tools</name>

--- a/traceevents/pom.xml
+++ b/traceevents/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.kotlin</groupId>
         <artifactId>kotlin-tools</artifactId>
-        <version>1.7.2</version>
+        <version>1.8.0</version>
     </parent>
 
     <artifactId>traceevents</artifactId>

--- a/traceevents/pom.xml
+++ b/traceevents/pom.xml
@@ -94,5 +94,11 @@
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>kotlinx-coroutines-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/traceevents/src/main/java/com/tomtom/kotlin/traceevents/Tracer.kt
+++ b/traceevents/src/main/java/com/tomtom/kotlin/traceevents/Tracer.kt
@@ -23,8 +23,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import java.io.PrintWriter
 import java.io.StringWriter

--- a/traceevents/src/main/java/com/tomtom/kotlin/traceevents/Tracer.kt
+++ b/traceevents/src/main/java/com/tomtom/kotlin/traceevents/Tracer.kt
@@ -16,8 +16,16 @@
 package com.tomtom.kotlin.traceevents
 
 import com.tomtom.kotlin.traceevents.TraceLog.LogLevel
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import java.io.PrintWriter
 import java.io.StringWriter
 import java.lang.reflect.InvocationHandler
@@ -393,7 +401,9 @@ public class Tracer private constructor(
      * function also outputs the trace using a logger, in this thread.
      */
     private fun offerTraceEvent(event: TraceEvent) {
-        if (!traceEventChannel.trySend(event).isSuccess) {
+        if (traceEventChannel.trySend(event).isSuccess) {
+            onTraceEventChannelUpdated()
+        } else {
             when (loggingMode) {
                 LoggingMode.SYNC ->
 
@@ -515,7 +525,8 @@ public class Tracer private constructor(
          * Capacity definition for the channel that queues traces.
          */
         private const val CHANNEL_CAPACITY = 10000
-        internal val traceEventChannel = Channel<TraceEvent>(CHANNEL_CAPACITY)
+        private val traceEventChannel = Channel<TraceEvent>(CHANNEL_CAPACITY)
+        private val traceEventChannelIsEmpty = MutableStateFlow(true)
         private val traceEventConsumers = TraceEventConsumerCollection()
 
         /**
@@ -618,6 +629,7 @@ public class Tracer private constructor(
                 while (traceEventChannel.tryReceive().getOrNull() != null) {
                     // Loop until queue is empty.
                 }
+                onTraceEventChannelUpdated()
             }.join()
 
             // Re-activate event processor if needed.
@@ -663,6 +675,7 @@ public class Tracer private constructor(
         private suspend fun processTraceEvents() {
             TraceLog.log(LogLevel.DEBUG, TAG, "Started trace event processor")
             for (traceEvent in traceEventChannel) {
+                onTraceEventChannelUpdated()
 
                 /**
                  * If the event processor is disabled, it simply discards all events
@@ -672,6 +685,34 @@ public class Tracer private constructor(
                     traceEventConsumers.consumeTraceEvent(traceEvent)
                 }
             }
+        }
+
+        /**
+         * Must be called after [traceEventChannel] has been updated, for example by calling
+         * [Channel.trySend] or removing elements by iterating over it.
+         *
+         * This updates whether the channel is empty. Though having to call this method to keep
+         * track of that is not ideal, there appears to be no better alternative. [Channel]s only
+         * allow receiving the elements within it (by a single collector) and do not allow observing
+         * updates to its queue.
+         */
+        @OptIn(ExperimentalCoroutinesApi::class)
+        private fun onTraceEventChannelUpdated() {
+            traceEventChannelIsEmpty.tryEmit(traceEventChannel.isEmpty)
+        }
+
+        /**
+         * A function that suspends until all queued trace events have been processed. It returns
+         * once the trace event queue is empty.
+         *
+         * This is not commonly needed in production use-cases, but can be valuable in tests to
+         * assert whether certain trace events were _not_ sent. When testing that a trace event was
+         * sent, it's typically sufficient to add a timeout on the verification. However, when
+         * testing that an event _wasn't_ sent, it is necessary to ensure that all queued trace
+         * events have been processed. Calling this method achieves that.
+         */
+        public suspend fun waitForEmptyTraceEventsQueue() {
+            traceEventChannelIsEmpty.first { it }
         }
 
         internal fun useSimpleLogFunction(

--- a/traceevents/src/test/java/com/tomtom/kotlin/traceevents/TracerTest.kt
+++ b/traceevents/src/test/java/com/tomtom/kotlin/traceevents/TracerTest.kt
@@ -661,13 +661,13 @@ internal class TracerTest {
         ) =
             match<TraceEvent> { traceEvent ->
                 traceEvent.logLevel == logLevel &&
-                        traceEvent.taggingClassName == TracerTest::class.jvmName &&
-                        traceEvent.context == context &&
-                        traceEvent.traceThreadLocalContext == traceThreadLocalContext &&
-                        traceEvent.interfaceName == MyEvents::class.jvmName &&
-                        traceEvent.eventName == functionName &&
-                        traceEvent.args.map { it?.javaClass } == args.map { it.javaClass } &&
-                        traceEvent.args.contentDeepEquals(args)
+                    traceEvent.taggingClassName == TracerTest::class.jvmName &&
+                    traceEvent.context == context &&
+                    traceEvent.traceThreadLocalContext == traceThreadLocalContext &&
+                    traceEvent.interfaceName == MyEvents::class.jvmName &&
+                    traceEvent.eventName == functionName &&
+                    traceEvent.args.map { it?.javaClass } == args.map { it.javaClass } &&
+                    traceEvent.args.contentDeepEquals(args)
             }
     }
 }

--- a/uid/pom.xml
+++ b/uid/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.kotlin</groupId>
         <artifactId>kotlin-tools</artifactId>
-        <version>1.7.2</version>
+        <version>1.8.0</version>
     </parent>
 
     <artifactId>uid</artifactId>


### PR DESCRIPTION
Added a `Tracer.hasQueuedTraceEvents: Boolean` to allow tests to wait for the trace event queue to be processed in order to assert that certain events were _not_ sent.