### PR TITLE
IVI-8309: Don't queue the events till processing starts

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,6 +659,10 @@ Contributors: Timon Kanters, Jeroen Erik Jensen, Krzysztof Karczewski
 
 ## Release notes
 
+### 1.8.1
+
+* Events traces are not queued till the processing starts.
+
 ### 1.8.0
 
 * Added `Tracer.hasQueuedTraceEvents: Boolean` to support testing that certain trace events were _not_ sent.

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.kotlin</groupId>
         <artifactId>kotlin-tools</artifactId>
-        <version>1.8.0</version>
+        <version>1.8.1</version>
     </parent>
 
     <artifactId>extensions</artifactId>

--- a/memoization/pom.xml
+++ b/memoization/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.kotlin</groupId>
         <artifactId>kotlin-tools</artifactId>
-        <version>1.8.0</version>
+        <version>1.8.1</version>
     </parent>
 
     <artifactId>memoization</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>com.tomtom.kotlin</groupId>
     <artifactId>kotlin-tools</artifactId>
-    <version>1.8.0</version>
+    <version>1.8.1</version>
     <packaging>pom</packaging>
 
     <name>Kotlin Tools</name>

--- a/traceevents/pom.xml
+++ b/traceevents/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.kotlin</groupId>
         <artifactId>kotlin-tools</artifactId>
-        <version>1.8.0</version>
+        <version>1.8.1</version>
     </parent>
 
     <artifactId>traceevents</artifactId>

--- a/uid/pom.xml
+++ b/uid/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.kotlin</groupId>
         <artifactId>kotlin-tools</artifactId>
-        <version>1.8.0</version>
+        <version>1.8.1</version>
     </parent>
 
     <artifactId>uid</artifactId>


### PR DESCRIPTION
Size of the event queue exceeds if consumer is not added. Therefore, after processing is started, queuing is enabled