### PR TITLE
Improve performance of Tracer.invoke() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,6 +659,21 @@ Contributors: Timon Kanters, Jeroen Erik Jensen, Krzysztof Karczewski
 
 ## Release notes
 
+### 1.8.3
+
+* Introduce caching of trace event method annotations in the `Tracer.invoke()` function.
+* Skip creation of a `TraceEvent` object if there are no event consumers. This saves us from performing an expensive
+  `LocalDateTime.now()` call.
+* Skip retrieval of trace event method annotations for simple log function invocations, if there are no event consumers.
+* Remove string concatenations in `createLogMessage()` functions. Only use `StringBuilder` functions.
+* Change `toStringRegistry` to use `item::javaClass.name` as key, and use `item::class.toString()` only as fallback.
+* Skip reading `item.javaClass.getMethod("toString").declaringClass` in `convertToStringUsingRegistry()`: the
+  `item.toString()` function of `Any` will anyway print the name of the class.
+* Fix execution of unit tests requiring mockk-jvm (`extensions` and `traceevents` modules): no unit test for these
+  modules was being run anymore, after the 1.8.2 update.
+* Fix the `IfExtensionsTest` unit tests: these tests were broken by mockk 1.13.4 (due to
+  https://github.com/mockk/mockk/issues/1033).
+
 ### 1.8.2
 
 * Dependencies updated.

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.kotlin</groupId>
         <artifactId>kotlin-tools</artifactId>
-        <version>1.8.2</version>
+        <version>1.8.3</version>
     </parent>
 
     <artifactId>extensions</artifactId>

--- a/extensions/src/test/java/com/tomtom/kotlin/extensions/IfExtensionsTest.kt
+++ b/extensions/src/test/java/com/tomtom/kotlin/extensions/IfExtensionsTest.kt
@@ -16,6 +16,7 @@
 
 package com.tomtom.kotlin.extensions
 
+import io.mockk.every
 import io.mockk.spyk
 import io.mockk.verify
 import kotlin.test.assertEquals
@@ -28,7 +29,10 @@ internal class IfExtensionsTest {
     fun `ifTrue on true`() {
         // GIVEN
         val sut = true
-        val ifTrueBlock = spyk({ 1 })
+        // TODO: replace with `spyk({ 1 })` when https://github.com/mockk/mockk/issues/1033 is fixed.
+        val ifTrueBlock: () -> Int = spyk {
+            every { this@spyk.invoke() } answers { 1 }
+        }
 
         // WHEN
         val result = sut.ifTrue(ifTrueBlock)
@@ -42,7 +46,10 @@ internal class IfExtensionsTest {
     fun `ifTrue on false`() {
         // GIVEN
         val sut = false
-        val ifTrueBlock = spyk({ 1 })
+        // TODO: replace with `spyk({ 1 })` when https://github.com/mockk/mockk/issues/1033 is fixed.
+        val ifTrueBlock: () -> Int = spyk {
+            every { this@spyk.invoke() } answers { 1 }
+        }
 
         // WHEN
         val result = sut.ifTrue(ifTrueBlock)
@@ -56,7 +63,10 @@ internal class IfExtensionsTest {
     fun `ifTrue on null`() {
         // GIVEN
         val sut: Boolean? = null
-        val ifTrueBlock = spyk({ 1 })
+        // TODO: replace with `spyk({ 1 })` when https://github.com/mockk/mockk/issues/1033 is fixed.
+        val ifTrueBlock: () -> Int = spyk {
+            every { this@spyk.invoke() } answers { 1 }
+        }
 
         // WHEN
         val result = sut.ifTrue(ifTrueBlock)
@@ -90,7 +100,10 @@ internal class IfExtensionsTest {
     fun `ifNull on null`() {
         // GIVEN
         val sut: Int? = null
-        val ifNullBlock = spyk({ 1 })
+        // TODO: replace with `spyk({ 1 })` when https://github.com/mockk/mockk/issues/1033 is fixed.
+        val ifNullBlock: () -> Int = spyk {
+            every { this@spyk.invoke() } answers { 1 }
+        }
 
         // WHEN
         val result = sut.ifNull(ifNullBlock)
@@ -108,7 +121,10 @@ internal class IfExtensionsTest {
     fun `ifNull with different types`() {
         // GIVEN
         val sut = A
-        val ifNullBlock = spyk({ B })
+        // TODO: replace with `spyk({ B })` when https://github.com/mockk/mockk/issues/1033 is fixed.
+        val ifNullBlock: () -> Base = spyk {
+            every { this@spyk.invoke() } answers { B }
+        }
 
         // WHEN
         val result: Base = sut.ifNull(ifNullBlock)

--- a/memoization/pom.xml
+++ b/memoization/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.kotlin</groupId>
         <artifactId>kotlin-tools</artifactId>
-        <version>1.8.2</version>
+        <version>1.8.3</version>
     </parent>
 
     <artifactId>memoization</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>com.tomtom.kotlin</groupId>
     <artifactId>kotlin-tools</artifactId>
-    <version>1.8.2</version>
+    <version>1.8.3</version>
     <packaging>pom</packaging>
 
     <name>Kotlin Tools</name>
@@ -100,7 +100,7 @@
         <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
         <maven-project-info-reports-plugin.version>3.4.2</maven-project-info-reports-plugin.version>
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
-        <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
 
         <!-- Library versions. -->
@@ -184,6 +184,13 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven-surefire-plugin.version}</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.apache.maven.surefire</groupId>
+                            <artifactId>surefire-junit4</artifactId>
+                            <version>3.1.2</version>
+                        </dependency>
+                    </dependencies>
             </plugin>
 
             <plugin>

--- a/traceevents/pom.xml
+++ b/traceevents/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.kotlin</groupId>
         <artifactId>kotlin-tools</artifactId>
-        <version>1.8.2</version>
+        <version>1.8.3</version>
     </parent>
 
     <artifactId>traceevents</artifactId>

--- a/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceLog.kt
+++ b/traceevents/src/main/java/com/tomtom/kotlin/traceevents/TraceLog.kt
@@ -66,7 +66,7 @@ public interface TraceLog {
             message: String,
             e: Throwable?
         ) = "[${LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME)}] $logLevel " +
-                "$tag: $message${e?.let { ", ${Tracer.formatThrowable(it, true)}" } ?: ""}"
+                "$tag: $message${e?.let { ", ${Tracer.formatThrowable(it)}" } ?: ""}"
 
         private var theLogger: Logger = DefaultLoggerToStdout
     }

--- a/traceevents/src/test/java/com/tomtom/kotlin/traceevents/AnnotationsTest.kt
+++ b/traceevents/src/test/java/com/tomtom/kotlin/traceevents/AnnotationsTest.kt
@@ -50,33 +50,73 @@ internal class AnnotationsTest {
 
     @Test
     fun `check function level annotations`() {
+        // GIVEN
         val tracer = Tracer.Factory.create<FunctionAnnotationEvents>(this)
+
+        // WHEN
         val actual = captureStdoutReplaceTime(TIME) {
             tracer.eventError()
             tracer.eventTaggingClass()
         }
+
+        // THEN
         val expected = "$TIME ERROR AnnotationsTest: event=eventError()\n" +
             "$TIME DEBUG AnnotationsTest: event=eventTaggingClass(), taggingClass=AnnotationsTest\n"
         assertEquals(expected, actual, NUMBER)
+
+        // WHEN a second set of events is invoked
+        val actual2 = captureStdoutReplaceTime(TIME) {
+            tracer.eventError()
+            tracer.eventTaggingClass()
+        }
+
+        // THEN the log message is still as expected
+        assertEquals(expected, actual2, NUMBER)
     }
 
     @Test
     fun `check interface level annotations`() {
+        // GIVEN
         val tracer = Tracer.Factory.create<InterfaceAnnotationsEvents>(this)
+
+        // WHEN
         val actual = captureStdoutReplaceTime(TIME) {
             tracer.event()
         }
+
+        // THEN
         val expected = "$TIME ERROR AnnotationsTest: event=event(), taggingClass=AnnotationsTest\n"
         assertEquals(expected, actual, NUMBER)
+
+        // WHEN a second event is invoked
+        val actual2 = captureStdoutReplaceTime(TIME) {
+            tracer.event()
+        }
+
+        // THEN the log message is still as expected
+        assertEquals(expected, actual2, NUMBER)
     }
 
     @Test
     fun `check mixed level annotations`() {
+        // GIVEN
         val tracer = Tracer.Factory.create<MixedAnnotationsEvents>(this)
+
+        // WHEN
         val actual = captureStdoutReplaceTime(TIME) {
             tracer.event()
         }
+
+        // THEN
         val expected = "$TIME ERROR AnnotationsTest: event=event(), taggingClass=AnnotationsTest\n"
         assertEquals(expected, actual, NUMBER)
+
+        // WHEN a second set of events is invoked
+        val actual2 = captureStdoutReplaceTime(TIME) {
+            tracer.event()
+        }
+
+        // THEN the log message is still as expected
+        assertEquals(expected, actual2, NUMBER)
     }
 }

--- a/uid/pom.xml
+++ b/uid/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.kotlin</groupId>
         <artifactId>kotlin-tools</artifactId>
-        <version>1.8.2</version>
+        <version>1.8.3</version>
     </parent>
 
     <artifactId>uid</artifactId>


### PR DESCRIPTION
Improve performance of `Tracer.invoke()`:
- ~70% improvement if there are no trace event consumers
- ~55% improvement if there are trace event consumers

Changes:
* Introduce caching of trace event method annotations in the `Tracer.invoke()` function.
* Skip creation of a `TraceEvent` object if there are no event consumers. This saves us from performing an expensive `LocalDateTime.now()` call.
* Skip retrieval of trace event method annotations for simple log function invocations, if there are no event consumers.
* Remove string concatenations in `createLogMessage()` functions. Only use `StringBuilder` functions.
* Change `toStringRegistry` to use `item::javaClass.name` as key, and use `item::class.toString()` only as fallback.
* Skip reading `item.javaClass.getMethod("toString").declaringClass` in `convertToStringUsingRegistry()`: the `item.toString()` function of `Any` will anyway print the name of the class.
* Fix execution of unit tests requiring mockk-jvm (`extensions` and `traceevents` modules): no unit test for these modules was being run anymore, after the 1.8.2 update.
* Fix the `IfExtensionsTest` unit tests: these tests were broken by mockk 1.13.4 (due to https://github.com/mockk/mockk/issues/1033).